### PR TITLE
회원 프로필 이미지 수정 / 삭제 기능

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -44,6 +44,16 @@ Groubing 서비스 Backend API 문서
 
 * link:member/MemberNicknameEdit.html[닉네임 변경 API,window=_blank]
 
+[[member-profile-edit]]
+=== 프로필 변경 API
+
+* link:member/MemberProfileEdit.html[프로필 변경 API,window=_blank]
+
+[[member-profile-delete]]
+=== 프로필 삭제 API
+
+* link:member/MemberProfileDelete.html[프로필 삭제 API,window=_blank]
+
 [[bingo]]
 == 빙고
 
@@ -76,5 +86,6 @@ Groubing 서비스 Backend API 문서
 
 [[bingo-item-update]]
 === 빙고 아이템 업데이트
+
 * link:bingo/BingoItemUpdate.html[빙고 아이템 업데이트,window=_blank]
 * link:bingo/BingoItemComplete.html[빙고 아이템 완료/완료취소,window=_blank]

--- a/src/docs/asciidoc/bingo/BingoItemComplete.adoc
+++ b/src/docs/asciidoc/bingo/BingoItemComplete.adoc
@@ -1,6 +1,8 @@
 [[bingo-item-complete-cancel]]
 === 빙고 아이템 완료
-operation::bingo-item-complete[snippets='request-body,request-fields,http-request,response-fields,http-response']
+
+operation::bingo-item-complete[snippets='http-request,http-response']
 
 === 빙고 아이템 완료 취소
-operation::bingo-item-cancel[snippets='request-body,request-fields,http-request,response-fields,http-response']
+
+operation::bingo-item-cancel[snippets='request-body,http-request,http-response']

--- a/src/docs/asciidoc/member/MemberProfileDelete.adoc
+++ b/src/docs/asciidoc/member/MemberProfileDelete.adoc
@@ -1,0 +1,4 @@
+[[member-profile-delete]]
+=== 프로필 삭제
+
+operation::member-profile-delete[snippets='path-parameters,http-request,http-response']

--- a/src/docs/asciidoc/member/MemberProfileEdit.adoc
+++ b/src/docs/asciidoc/member/MemberProfileEdit.adoc
@@ -1,0 +1,4 @@
+[[member-profile-edit]]
+=== 프로필 변경
+
+operation::member-profile-edit[snippets='path-parameters,request-parts,http-request,response-body,response-fields,http-response']

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileDeleteApi.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileDeleteApi.kt
@@ -1,0 +1,20 @@
+package com.beside.groubing.groubingserver.domain.member.api
+
+import com.beside.groubing.groubingserver.domain.member.application.MemberProfileDeleteService
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/members")
+class MemberProfileDeleteApi(
+    private val memberProfileDeleteService: MemberProfileDeleteService
+) {
+    @DeleteMapping("/{id}/profile")
+    fun deleteProfile(
+        @PathVariable id: Long
+    ) {
+        memberProfileDeleteService.delete(id)
+    }
+}

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApi.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApi.kt
@@ -3,8 +3,8 @@ package com.beside.groubing.groubingserver.domain.member.api
 import com.beside.groubing.groubingserver.domain.member.application.MemberProfileEditService
 import com.beside.groubing.groubingserver.domain.member.payload.response.MemberProfileResponse
 import com.beside.groubing.groubingserver.global.response.ApiResponse
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
@@ -15,7 +15,7 @@ import org.springframework.web.multipart.MultipartFile
 class MemberProfileEditApi(
     private val memberProfileEditService: MemberProfileEditService
 ) {
-    @PostMapping("/{id}/profile")
+    @PatchMapping("/{id}/profile")
     fun editProfile(
         @PathVariable id: Long,
         @RequestPart profile: MultipartFile

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApi.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApi.kt
@@ -1,0 +1,27 @@
+package com.beside.groubing.groubingserver.domain.member.api
+
+import com.beside.groubing.groubingserver.domain.member.application.MemberProfileEditService
+import com.beside.groubing.groubingserver.domain.member.payload.response.MemberProfileResponse
+import com.beside.groubing.groubingserver.global.response.ApiResponse
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/members")
+class MemberProfileEditApi(
+    private val memberProfileEditService: MemberProfileEditService
+) {
+    @PostMapping("/{id}/profile")
+    fun editProfile(
+        @PathVariable id: Long,
+        @RequestPart profile: MultipartFile
+    ): ApiResponse<MemberProfileResponse> {
+        val profileUrl = memberProfileEditService.deleteAndEdit(id, profile)
+        val response = MemberProfileResponse(profileUrl)
+        return ApiResponse.OK(response)
+    }
+}

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApi.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApi.kt
@@ -20,7 +20,7 @@ class MemberProfileEditApi(
         @PathVariable id: Long,
         @RequestPart profile: MultipartFile
     ): ApiResponse<MemberProfileResponse> {
-        val profileUrl = memberProfileEditService.deleteAndEdit(id, profile)
+        val profileUrl = memberProfileEditService.edit(id, profile)
         val response = MemberProfileResponse(profileUrl)
         return ApiResponse.OK(response)
     }

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/application/MemberProfileDeleteService.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/application/MemberProfileDeleteService.kt
@@ -2,17 +2,23 @@ package com.beside.groubing.groubingserver.domain.member.application
 
 import com.beside.groubing.groubingserver.domain.member.dao.MemberFindDao
 import com.beside.groubing.groubingserver.global.domain.file.application.FileProvider
+import com.beside.groubing.groubingserver.global.domain.file.domain.FileInfoRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 @Transactional
 class MemberProfileDeleteService(
-    private val memberFindDao: MemberFindDao
+    private val memberFindDao: MemberFindDao,
+    private val fileInfoRepository: FileInfoRepository
 ) {
     fun delete(id: Long) {
         val member = memberFindDao.findExistingMemberById(id)
-        FileProvider.delete(member.profile)
+        val profile = member.profile
+        if (profile != null) {
+            FileProvider.delete(profile)
+            fileInfoRepository.delete(profile)
+        }
         member.deleteProfile()
     }
 }

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/application/MemberProfileDeleteService.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/application/MemberProfileDeleteService.kt
@@ -1,0 +1,18 @@
+package com.beside.groubing.groubingserver.domain.member.application
+
+import com.beside.groubing.groubingserver.domain.member.dao.MemberFindDao
+import com.beside.groubing.groubingserver.global.domain.file.application.FileProvider
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class MemberProfileDeleteService(
+    private val memberFindDao: MemberFindDao
+) {
+    fun delete(id: Long) {
+        val member = memberFindDao.findExistingMemberById(id)
+        FileProvider.delete(member.profile)
+        member.deleteProfile()
+    }
+}

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/application/MemberProfileEditService.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/application/MemberProfileEditService.kt
@@ -15,7 +15,7 @@ class MemberProfileEditService(
     private val memberFindDao: MemberFindDao,
     private val fileInfoRepository: FileInfoRepository
 ) {
-    fun deleteAndEdit(id: Long, profile: MultipartFile): String {
+    fun edit(id: Long, profile: MultipartFile): String {
         val member = memberFindDao.findExistingMemberById(id)
         delete(member.profile)
         edit(member, profile)

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/application/MemberProfileEditService.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/application/MemberProfileEditService.kt
@@ -1,0 +1,36 @@
+package com.beside.groubing.groubingserver.domain.member.application
+
+import com.beside.groubing.groubingserver.domain.member.dao.MemberFindDao
+import com.beside.groubing.groubingserver.domain.member.domain.Member
+import com.beside.groubing.groubingserver.global.domain.file.application.FileProvider
+import com.beside.groubing.groubingserver.global.domain.file.domain.FileInfo
+import com.beside.groubing.groubingserver.global.domain.file.domain.FileInfoRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+@Transactional
+class MemberProfileEditService(
+    private val memberFindDao: MemberFindDao,
+    private val fileInfoRepository: FileInfoRepository
+) {
+    fun deleteAndEdit(id: Long, profile: MultipartFile): String {
+        val member = memberFindDao.findExistingMemberById(id)
+        delete(member.profile)
+        edit(member, profile)
+        return member.profile!!.url
+    }
+
+    private fun delete(beforeProfile: FileInfo?) {
+        if (beforeProfile != null) {
+            FileProvider.delete(beforeProfile)
+            fileInfoRepository.delete(beforeProfile)
+        }
+    }
+
+    private fun edit(member: Member, newProfileFile: MultipartFile) {
+        val newProfile = FileProvider.upload(newProfileFile)
+        member.editProfile(newProfile)
+    }
+}

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/domain/Member.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/domain/Member.kt
@@ -1,14 +1,19 @@
 package com.beside.groubing.groubingserver.domain.member.domain
 
 import com.beside.groubing.groubingserver.domain.member.exception.MemberInputException
+import com.beside.groubing.groubingserver.global.domain.file.domain.FileInfo
 import com.beside.groubing.groubingserver.global.domain.jpa.BaseEntity
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 
@@ -23,7 +28,7 @@ class Member internal constructor(
     password: String,
     nickname: String,
     @Enumerated(EnumType.STRING)
-    @Column(name = "role")
+    @Column(name = "ROLE")
     val role: MemberRole
 ) : BaseEntity() {
     var password: String = password
@@ -31,6 +36,10 @@ class Member internal constructor(
 
     var nickname: String = nickname
         private set
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+    @JoinColumn(name = "PROFILE_ID")
+    var profile: FileInfo? = null
 
     fun matches(password: String, passwordEncoder: BCryptPasswordEncoder) {
         if (!passwordEncoder.matches(password, this.password)) {
@@ -51,6 +60,14 @@ class Member internal constructor(
         val startIndex = endIndex / 2
         val replacement = (startIndex until endIndex).map { '*' }.joinToString("")
         return StringBuilder(email).replace(startIndex, endIndex, replacement).toString()
+    }
+
+    fun editProfile(profile: FileInfo) {
+        this.profile = profile
+    }
+
+    fun deleteProfile() {
+        this.profile = null
     }
 
     companion object {

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/domain/Member.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/domain/Member.kt
@@ -13,7 +13,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 
@@ -37,7 +37,7 @@ class Member internal constructor(
     var nickname: String = nickname
         private set
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+    @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     @JoinColumn(name = "PROFILE_ID")
     var profile: FileInfo? = null
 

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/payload/response/MemberProfileResponse.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/member/payload/response/MemberProfileResponse.kt
@@ -1,0 +1,5 @@
+package com.beside.groubing.groubingserver.domain.member.payload.response
+
+data class MemberProfileResponse(
+    val profileUrl: String
+)

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/config/SecurityConfig.kt
@@ -18,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 class SecurityConfig {
     companion object {
+        private val GET_AUTH_WHITELIST = arrayOf("/api/download/*")
         private val POST_AUTH_WHITELIST = arrayOf("/api/members", "/api/members/login", "/api/members/find-email")
         private val PATCH_AUTH_WHITELIST = arrayOf("/api/members/*/password")
         private val STATIC_RESOURCES = arrayOf("/docs/**", "/*/*.png", "/***.jpg", "/*/*.jpeg")
@@ -32,6 +33,8 @@ class SecurityConfig {
             .csrf()
             .disable()
             .authorizeHttpRequests()
+            .requestMatchers(HttpMethod.GET, *GET_AUTH_WHITELIST)
+            .permitAll()
             .requestMatchers(HttpMethod.POST, *POST_AUTH_WHITELIST)
             .permitAll()
             .requestMatchers(HttpMethod.PATCH, *PATCH_AUTH_WHITELIST)

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/config/SecurityConfig.kt
@@ -18,7 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 class SecurityConfig {
     companion object {
-        private val GET_AUTH_WHITELIST = arrayOf("/api/download/*")
+        private val GET_AUTH_WHITELIST = arrayOf("/api/files/*")
         private val POST_AUTH_WHITELIST = arrayOf("/api/members", "/api/members/login", "/api/members/find-email")
         private val PATCH_AUTH_WHITELIST = arrayOf("/api/members/*/password")
         private val STATIC_RESOURCES = arrayOf("/docs/**", "/*/*.png", "/***.jpg", "/*/*.jpeg")

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/api/FileDownloadApi.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/api/FileDownloadApi.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api/download")
+@RequestMapping("/api/files")
 class FileDownloadApi(
     private val fileInfoService: FileInfoService
 ) {

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/api/FileDownloadApi.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/api/FileDownloadApi.kt
@@ -1,0 +1,26 @@
+package com.beside.groubing.groubingserver.global.domain.file.api
+
+import com.beside.groubing.groubingserver.global.domain.file.application.FileInfoService
+import com.beside.groubing.groubingserver.global.domain.file.application.FileProvider
+import org.springframework.core.io.Resource
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/download")
+class FileDownloadApi(
+    private val fileInfoService: FileInfoService
+) {
+    @GetMapping("/{fileName:.+}")
+    fun download(
+        @PathVariable fileName: String
+    ): ResponseEntity<Resource> {
+        val resource = fileInfoService.findByFileName(fileName)
+        return ResponseEntity.ok()
+            .contentType(FileProvider.getContentType(fileName))
+            .body(resource)
+    }
+}

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/application/FileInfoService.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/application/FileInfoService.kt
@@ -1,0 +1,16 @@
+package com.beside.groubing.groubingserver.global.domain.file.application
+
+import com.beside.groubing.groubingserver.global.domain.file.domain.FileInfoRepository
+import com.beside.groubing.groubingserver.global.domain.file.exception.FileInfoInputException
+import org.springframework.core.io.Resource
+import org.springframework.stereotype.Service
+
+@Service
+class FileInfoService(
+    private val fileInfoRepository: FileInfoRepository
+) {
+    fun findByFileName(fileName: String): Resource {
+        val fileInfo = fileInfoRepository.findFirstByFileName(fileName) ?: throw FileInfoInputException()
+        return FileProvider.find(fileInfo)
+    }
+}

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/application/FileProvider.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/application/FileProvider.kt
@@ -31,8 +31,8 @@ class FileProvider {
             return FileInfo.create(directory, fileName, file.originalFilename!!)
         }
 
-        fun delete(fileInfo: FileInfo?) {
-            if (fileInfo != null) Files.deleteIfExists(fileInfo.getAbsolutePath())
+        fun delete(fileInfo: FileInfo) {
+            Files.deleteIfExists(fileInfo.getAbsolutePath())
         }
 
         fun find(fileInfo: FileInfo): Resource {

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/application/FileProvider.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/application/FileProvider.kt
@@ -1,0 +1,70 @@
+package com.beside.groubing.groubingserver.global.domain.file.application
+
+import com.beside.groubing.groubingserver.global.domain.file.domain.FileInfo
+import org.springframework.core.io.Resource
+import org.springframework.core.io.UrlResource
+import org.springframework.http.MediaType
+import org.springframework.util.StringUtils
+import org.springframework.web.multipart.MultipartException
+import org.springframework.web.multipart.MultipartFile
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+
+class FileProvider {
+    companion object {
+        private val root = System.getProperty("user.home")
+        private val IMAGE_FORMAT = listOf("png", "jpeg", "jpg")
+
+        fun upload(file: MultipartFile): FileInfo {
+            validateFormat(file)
+            val fileName = createFileName(file)
+            val directory = getDirectory()
+            val path = Paths.get("$root/$directory")
+            val newFile = File(path.toUri().path, fileName)
+            if (!newFile.exists()) Files.createDirectories(path)
+            file.transferTo(newFile)
+            return FileInfo.create(directory, fileName, file.originalFilename!!)
+        }
+
+        fun delete(fileInfo: FileInfo?) {
+            if (fileInfo != null) Files.deleteIfExists(fileInfo.getAbsolutePath())
+        }
+
+        fun find(fileInfo: FileInfo): Resource {
+            val path = fileInfo.getAbsolutePath()
+            return UrlResource(path.toUri())
+        }
+
+        fun getContentType(fileName: String): MediaType {
+            val fileFormat = StringUtils.getFilenameExtension(fileName)
+            if (IMAGE_FORMAT[0].equals(fileFormat, ignoreCase = true)) return MediaType.IMAGE_PNG
+            return MediaType.IMAGE_JPEG
+        }
+
+        private fun validateFormat(file: MultipartFile) {
+            if (file.isEmpty) throw MultipartException("파일이 정상적으로 업로드되지 않았습니다")
+            val fileFormat = getFileFormat(file)
+            val isIncludeFormat = IMAGE_FORMAT.any { format -> format.equals(fileFormat, ignoreCase = true) }
+            if (!isIncludeFormat) throw MultipartException(".png / .jpg / .jpeg 형식의 파일만 업로드 가능합니다.")
+        }
+
+        private fun createFileName(file: MultipartFile): String {
+            val fileFormat = getFileFormat(file)
+            return "${System.currentTimeMillis()}-${UUID.randomUUID()}.$fileFormat"
+        }
+
+        private fun getFileFormat(file: MultipartFile): String? {
+            val originalFilename = file.originalFilename
+            return StringUtils.getFilenameExtension(originalFilename)
+        }
+
+        private fun getDirectory(): String {
+            return "/groubing/${LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))}"
+        }
+    }
+}

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/domain/FileInfo.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/domain/FileInfo.kt
@@ -23,7 +23,7 @@ class FileInfo private constructor(
     val id: Long = 0L
 
     val url: String
-        get() = "/api/download/$fileName"
+        get() = "/api/files/$fileName"
 
     fun getAbsolutePath(): Path {
         val root = System.getProperty("user.home")

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/domain/FileInfo.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/domain/FileInfo.kt
@@ -1,0 +1,38 @@
+package com.beside.groubing.groubingserver.global.domain.file.domain
+
+import com.beside.groubing.groubingserver.global.domain.jpa.BaseCreatedTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.nio.file.Path
+import java.nio.file.Paths
+
+@Entity
+@Table(name = "FILE_INFO")
+class FileInfo private constructor(
+    private val directory: String,
+    private val fileName: String,
+    private val originalName: String
+) : BaseCreatedTimeEntity() {
+    @Id
+    @Column(name = "FILE_ID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+    val url: String
+        get() = "/api/download/$fileName"
+
+    fun getAbsolutePath(): Path {
+        val root = System.getProperty("user.home")
+        return Paths.get("$root/$directory", fileName)
+    }
+
+    companion object {
+        fun create(directory: String, fileName: String, originalName: String): FileInfo {
+            return FileInfo(directory, fileName, originalName)
+        }
+    }
+}

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/domain/FileInfo.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/domain/FileInfo.kt
@@ -11,7 +11,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 @Entity
-@Table(name = "FILE_INFO")
+@Table(name = "FILE_INFOS")
 class FileInfo private constructor(
     private val directory: String,
     private val fileName: String,

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/domain/FileInfoRepository.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/domain/FileInfoRepository.kt
@@ -1,0 +1,9 @@
+package com.beside.groubing.groubingserver.global.domain.file.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface FileInfoRepository : JpaRepository<FileInfo, Long> {
+    fun findFirstByFileName(fileName: String): FileInfo?
+}

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/exception/FileInfoInputException.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/domain/file/exception/FileInfoInputException.kt
@@ -1,0 +1,3 @@
+package com.beside.groubing.groubingserver.global.domain.file.exception
+
+class FileInfoInputException : RuntimeException("[FileInfoInputException] 해당 파일명의 데이터가 존재하지 않습니다.")

--- a/src/main/kotlin/com/beside/groubing/groubingserver/global/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/global/handler/GlobalExceptionHandler.kt
@@ -2,6 +2,7 @@ package com.beside.groubing.groubingserver.global.handler
 
 import com.beside.groubing.groubingserver.domain.bingo.exception.BingoInputException
 import com.beside.groubing.groubingserver.domain.member.exception.MemberInputException
+import com.beside.groubing.groubingserver.global.domain.file.exception.FileInfoInputException
 import com.beside.groubing.groubingserver.global.response.ApiResponseCode
 import com.beside.groubing.groubingserver.global.response.error.ApiError
 import org.hibernate.exception.ConstraintViolationException
@@ -63,6 +64,12 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(BingoInputException::class)
     fun handle(e: BingoInputException): ResponseEntity<ApiError> {
+        val apiError = ApiError(ApiResponseCode.BAD_MEMBER_INPUT, e)
+        return ResponseEntity(apiError, HttpStatus.BAD_REQUEST)
+    }
+
+    @ExceptionHandler(FileInfoInputException::class)
+    fun handle(e: FileInfoInputException): ResponseEntity<ApiError> {
         val apiError = ApiError(ApiResponseCode.BAD_MEMBER_INPUT, e)
         return ResponseEntity(apiError, HttpStatus.BAD_REQUEST)
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,7 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
+  servlet:
+    multipart:
+      max-file-size: 3MB
+      max-request-size: 3MB

--- a/src/test/kotlin/com/beside/groubing/groubingserver/docs/CustomDescriptor.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/docs/CustomDescriptor.kt
@@ -5,6 +5,8 @@ import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.request.ParameterDescriptor
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.partWithName
+import org.springframework.restdocs.request.RequestPartDescriptor
 import org.springframework.restdocs.snippet.IgnorableDescriptor
 
 open class CustomDescriptor<T : IgnorableDescriptor<T>>(
@@ -65,6 +67,7 @@ open class CustomDescriptor<T : IgnorableDescriptor<T>>(
         when {
             value && descriptor is FieldDescriptor -> descriptor.optional()
             value && descriptor is ParameterDescriptor -> descriptor.optional()
+            value && descriptor is RequestPartDescriptor -> descriptor.optional()
         }
         return this
     }
@@ -140,11 +143,24 @@ private fun createField(
     return CustomDescriptor(descriptor)
 }
 
-infix fun String.optional(optional: Boolean): CustomDescriptor<ParameterDescriptor> = createParameter(this, optional)
+infix fun String.requestParam(description: String): CustomDescriptor<ParameterDescriptor> =
+    createParameter(this, description)
 
-private fun createParameter(value: String, optional: Boolean): CustomDescriptor<ParameterDescriptor> {
-    val descriptor = parameterWithName(value).description("")
-    if (optional) descriptor.optional()
+private fun createParameter(value: String, description: String): CustomDescriptor<ParameterDescriptor> {
+    val descriptor = parameterWithName(value)
+        .attributes(RestDocsUtils.emptyExample(), RestDocsUtils.emptyFormat(), RestDocsUtils.emptyDefaultValue())
+        .description(description)
+
+    return CustomDescriptor(descriptor)
+}
+
+infix fun String.requestPart(description: String): CustomDescriptor<RequestPartDescriptor> =
+    createPart(this, description)
+
+private fun createPart(value: String, description: String): CustomDescriptor<RequestPartDescriptor> {
+    val descriptor = partWithName(value)
+        .attributes(RestDocsUtils.emptyExample(), RestDocsUtils.emptyFormat(), RestDocsUtils.emptyDefaultValue())
+        .description(description)
 
     return CustomDescriptor(descriptor)
 }

--- a/src/test/kotlin/com/beside/groubing/groubingserver/docs/RestDocsExtensions.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/docs/RestDocsExtensions.kt
@@ -10,6 +10,8 @@ import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.restdocs.request.ParameterDescriptor
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.restdocs.request.RequestDocumentation.requestParts
+import org.springframework.restdocs.request.RequestPartDescriptor
 import org.springframework.restdocs.snippet.Snippet
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.ResultActionsDsl
@@ -28,6 +30,10 @@ fun responseBody(vararg fields: CustomDescriptor<FieldDescriptor>): Snippet {
 
 fun pathVariables(vararg paths: CustomDescriptor<ParameterDescriptor>): Snippet =
     pathParameters(paths.map { it.descriptor as ParameterDescriptor })
+
+fun requestParts(vararg fields: CustomDescriptor<RequestPartDescriptor>): Snippet {
+    return requestParts(fields.map { it.descriptor as RequestPartDescriptor })
+}
 
 fun ResultActionsDsl.andDocument(identifier: String, vararg snippets: Snippet) {
     andDo {

--- a/src/test/kotlin/com/beside/groubing/groubingserver/domain/bingo/api/BingoBoardFindApiTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/domain/bingo/api/BingoBoardFindApiTest.kt
@@ -9,8 +9,8 @@ import com.beside.groubing.groubingserver.docs.ENUM
 import com.beside.groubing.groubingserver.docs.NUMBER
 import com.beside.groubing.groubingserver.docs.STRING
 import com.beside.groubing.groubingserver.docs.andDocument
-import com.beside.groubing.groubingserver.docs.optional
 import com.beside.groubing.groubingserver.docs.pathVariables
+import com.beside.groubing.groubingserver.docs.requestParam
 import com.beside.groubing.groubingserver.docs.responseBody
 import com.beside.groubing.groubingserver.docs.responseType
 import com.beside.groubing.groubingserver.domain.bingo.application.BingoBoardFindService
@@ -56,7 +56,7 @@ class BingoBoardFindApiTest(
                 .andDocument(
                     "bingo-board-find",
                     pathVariables(
-                        "id" optional true means "빙고 ID" example "1"
+                        "id" requestParam "빙고 ID" example "1" isOptional true
                     ),
                     responseBody(
                         "id" responseType NUMBER means "빙고 ID" example "1",

--- a/src/test/kotlin/com/beside/groubing/groubingserver/domain/bingo/api/BingoItemCompleteApiTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/domain/bingo/api/BingoItemCompleteApiTest.kt
@@ -3,8 +3,8 @@ package com.beside.groubing.groubingserver.domain.bingo.api
 import com.beside.groubing.groubingserver.aEnglishStudyBingoBoard
 import com.beside.groubing.groubingserver.config.ApiTest
 import com.beside.groubing.groubingserver.docs.andDocument
-import com.beside.groubing.groubingserver.docs.optional
 import com.beside.groubing.groubingserver.docs.pathVariables
+import com.beside.groubing.groubingserver.docs.requestParam
 import com.beside.groubing.groubingserver.domain.bingo.application.BingoItemCompleteService
 import com.beside.groubing.groubingserver.extension.getHttpHeaderJwt
 import com.ninjasquad.springmockk.MockkBean
@@ -31,7 +31,11 @@ class BingoItemCompleteApiTest(
 
         When("완료 요청 시") {
             mockMvc.perform(
-                RestDocumentationRequestBuilders.patch("/api/bingo-boards/{id}/bingo-items/{bingoItemId}/complete", englishBingoBoard.id, bingoItem.id)
+                RestDocumentationRequestBuilders.patch(
+                    "/api/bingo-boards/{id}/bingo-items/{bingoItemId}/complete",
+                    englishBingoBoard.id,
+                    bingoItem.id
+                )
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
                     .header("Authorization", getHttpHeaderJwt(memberId))
@@ -40,8 +44,8 @@ class BingoItemCompleteApiTest(
                 .andDocument(
                     "bingo-item-complete",
                     pathVariables(
-                        "id" optional true means "빙고 ID" example "1",
-                        "bingoItemId" optional true means "빙고 아이템 ID" example "1"
+                        "id" requestParam "빙고 ID" example "1" isOptional true,
+                        "bingoItemId" requestParam "빙고 아이템 ID" example "1" isOptional true
                     )
                 )
         }
@@ -49,7 +53,11 @@ class BingoItemCompleteApiTest(
         every { bingoItemCompleteService.cancelBingoItem(englishBingoBoard.id, bingoItem.id, memberId) } returns Unit
         When("취소 요청 시") {
             mockMvc.perform(
-                RestDocumentationRequestBuilders.patch("/api/bingo-boards/{id}/bingo-items/{bingoItemId}/cancel", englishBingoBoard.id, bingoItem.id)
+                RestDocumentationRequestBuilders.patch(
+                    "/api/bingo-boards/{id}/bingo-items/{bingoItemId}/cancel",
+                    englishBingoBoard.id,
+                    bingoItem.id
+                )
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
                     .header("Authorization", getHttpHeaderJwt(memberId))
@@ -58,8 +66,8 @@ class BingoItemCompleteApiTest(
                 .andDocument(
                     "bingo-item-cancel",
                     pathVariables(
-                        "id" optional true means "빙고 ID" example "1",
-                        "bingoItemId" optional true means "빙고 아이템 ID" example "1"
+                        "id" requestParam "빙고 ID" example "1" isOptional true,
+                        "bingoItemId" requestParam "빙고 아이템 ID" example "1" isOptional true
                     )
                 )
         }

--- a/src/test/kotlin/com/beside/groubing/groubingserver/domain/bingo/api/BingoItemUpdateApiTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/domain/bingo/api/BingoItemUpdateApiTest.kt
@@ -6,9 +6,9 @@ import com.beside.groubing.groubingserver.docs.BOOLEAN
 import com.beside.groubing.groubingserver.docs.NUMBER
 import com.beside.groubing.groubingserver.docs.STRING
 import com.beside.groubing.groubingserver.docs.andDocument
-import com.beside.groubing.groubingserver.docs.optional
 import com.beside.groubing.groubingserver.docs.pathVariables
 import com.beside.groubing.groubingserver.docs.requestBody
+import com.beside.groubing.groubingserver.docs.requestParam
 import com.beside.groubing.groubingserver.docs.requestType
 import com.beside.groubing.groubingserver.docs.responseBody
 import com.beside.groubing.groubingserver.docs.responseType
@@ -47,7 +47,11 @@ class BingoItemUpdateApiTest(
 
         When("데이터가 유효하다면") {
             mockMvc.perform(
-                RestDocumentationRequestBuilders.put("/api/bingo-boards/{id}/bingo-items/{bingoItemId}", aEmptyBingo.id, bingoItem.id)
+                RestDocumentationRequestBuilders.put(
+                    "/api/bingo-boards/{id}/bingo-items/{bingoItemId}",
+                    aEmptyBingo.id,
+                    bingoItem.id
+                )
                     .content(mapper.writeValueAsString(request))
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
@@ -57,8 +61,8 @@ class BingoItemUpdateApiTest(
                 .andDocument(
                     "bingo-item-update",
                     pathVariables(
-                        "id" optional true means "빙고 ID" example "1",
-                        "bingoItemId" optional true means "빙고 아이템 ID" example "1"
+                        "id" requestParam "빙고 ID" example "1" isOptional true,
+                        "bingoItemId" requestParam "빙고 아이템 ID" example "1" isOptional true
                     ),
                     requestBody(
                         "title" requestType STRING means "빙고 아이템 제목" example request.title,

--- a/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberNicknameEditApiTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberNicknameEditApiTest.kt
@@ -3,9 +3,9 @@ package com.beside.groubing.groubingserver.domain.member.api
 import com.beside.groubing.groubingserver.config.ApiTest
 import com.beside.groubing.groubingserver.docs.STRING
 import com.beside.groubing.groubingserver.docs.andDocument
-import com.beside.groubing.groubingserver.docs.optional
 import com.beside.groubing.groubingserver.docs.pathVariables
 import com.beside.groubing.groubingserver.docs.requestBody
+import com.beside.groubing.groubingserver.docs.requestParam
 import com.beside.groubing.groubingserver.docs.requestType
 import com.beside.groubing.groubingserver.domain.member.application.MemberNicknameEditService
 import com.beside.groubing.groubingserver.domain.member.payload.request.MemberNicknameEditRequest
@@ -54,7 +54,7 @@ class MemberNicknameEditApiTest(
                     .andDocument(
                         "member-nickname-edit",
                         pathVariables(
-                            "id" optional true means "회원 ID" example id.toString()
+                            "id" requestParam "회원 ID" example id.toString() isOptional true
                         ),
                         requestBody(
                             "nickname" requestType STRING means "닉네임" example nickname formattedAs "^[가-힣a-zA-Z0-9]{2,7}"

--- a/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberPasswordResetApiTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberPasswordResetApiTest.kt
@@ -3,9 +3,9 @@ package com.beside.groubing.groubingserver.domain.member.api
 import com.beside.groubing.groubingserver.config.ApiTest
 import com.beside.groubing.groubingserver.docs.STRING
 import com.beside.groubing.groubingserver.docs.andDocument
-import com.beside.groubing.groubingserver.docs.optional
 import com.beside.groubing.groubingserver.docs.pathVariables
 import com.beside.groubing.groubingserver.docs.requestBody
+import com.beside.groubing.groubingserver.docs.requestParam
 import com.beside.groubing.groubingserver.docs.requestType
 import com.beside.groubing.groubingserver.domain.member.application.MemberPasswordResetService
 import com.beside.groubing.groubingserver.domain.member.payload.request.MemberPasswordResetRequest
@@ -54,7 +54,7 @@ class MemberPasswordResetApiTest(
                     .andDocument(
                         "member-password-reset",
                         pathVariables(
-                            "id" optional true means "회원 ID" example id.toString()
+                            "id" requestParam "회원 ID" example id.toString() isOptional true
                         ),
                         requestBody(
                             "password" requestType STRING means "유저 패스워드" example password formattedAs "^[a-zA-Z0-9!-/:-@\\[-_~]{8,20}"

--- a/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileDeleteApiTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileDeleteApiTest.kt
@@ -1,0 +1,45 @@
+package com.beside.groubing.groubingserver.domain.member.api
+
+import com.beside.groubing.groubingserver.config.ApiTest
+import com.beside.groubing.groubingserver.docs.andDocument
+import com.beside.groubing.groubingserver.docs.pathVariables
+import com.beside.groubing.groubingserver.docs.requestParam
+import com.beside.groubing.groubingserver.domain.member.application.MemberProfileDeleteService
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.single
+import io.mockk.justRun
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@ApiTest
+@WebMvcTest(controllers = [MemberProfileDeleteApi::class])
+class MemberProfileDeleteApiTest(
+    private val mockMvc: MockMvc,
+    @MockkBean private val memberProfileDeleteService: MemberProfileDeleteService
+) : BehaviorSpec({
+    Given("유저가") {
+        val id = Arb.long(1L..100L).single()
+
+        When("기존에 등록한 프로필 이미지를 삭제할 경우") {
+            justRun { memberProfileDeleteService.delete(any()) }
+
+            Then("성공 응답을 리턴한다.") {
+                mockMvc.perform(delete("/api/members/{id}/profile", id))
+                    .andDo(print())
+                    .andExpect(status().isOk)
+                    .andDocument(
+                        "member-profile-delete",
+                        pathVariables(
+                            "id" requestParam "회원 ID" example id.toString()
+                        )
+                    )
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApiTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApiTest.kt
@@ -11,6 +11,7 @@ import com.beside.groubing.groubingserver.docs.responseBody
 import com.beside.groubing.groubingserver.docs.responseType
 import com.beside.groubing.groubingserver.domain.member.application.MemberProfileEditService
 import com.beside.groubing.groubingserver.domain.member.payload.response.MemberProfileResponse
+import com.beside.groubing.groubingserver.extension.multipart
 import com.beside.groubing.groubingserver.global.domain.file.domain.FileInfo
 import com.beside.groubing.groubingserver.global.response.ApiResponse
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -22,9 +23,9 @@ import io.kotest.property.arbitrary.single
 import io.mockk.every
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.core.io.InputStreamResource
+import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -55,7 +56,7 @@ class MemberProfileEditApiTest(
 
             Then("프로필 이미지 URL 을 응답하도록 한다.") {
                 mockMvc.perform(
-                    multipart("/api/members/{id}/profile", id)
+                    multipart(HttpMethod.PATCH, "/api/members/{id}/profile", id)
                         .file(profile)
                 ).andDo(print())
                     .andExpect(status().isOk)

--- a/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApiTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApiTest.kt
@@ -50,7 +50,7 @@ class MemberProfileEditApiTest(
         val fileInfo = FileInfo.create("/groubing", fileName, profile.originalFilename)
 
         When("새로운 프로필 이미지를 등록하는 경우") {
-            every { memberProfileEditService.deleteAndEdit(any(), any()) } returns fileInfo.url
+            every { memberProfileEditService.edit(any(), any()) } returns fileInfo.url
             val response = MemberProfileResponse(fileInfo.url)
 
             Then("프로필 이미지 URL 을 응답하도록 한다.") {

--- a/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApiTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/domain/member/api/MemberProfileEditApiTest.kt
@@ -1,0 +1,78 @@
+package com.beside.groubing.groubingserver.domain.member.api
+
+import com.beside.groubing.groubingserver.config.ApiTest
+import com.beside.groubing.groubingserver.docs.STRING
+import com.beside.groubing.groubingserver.docs.andDocument
+import com.beside.groubing.groubingserver.docs.pathVariables
+import com.beside.groubing.groubingserver.docs.requestParam
+import com.beside.groubing.groubingserver.docs.requestPart
+import com.beside.groubing.groubingserver.docs.requestParts
+import com.beside.groubing.groubingserver.docs.responseBody
+import com.beside.groubing.groubingserver.docs.responseType
+import com.beside.groubing.groubingserver.domain.member.application.MemberProfileEditService
+import com.beside.groubing.groubingserver.domain.member.payload.response.MemberProfileResponse
+import com.beside.groubing.groubingserver.global.domain.file.domain.FileInfo
+import com.beside.groubing.groubingserver.global.response.ApiResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.single
+import io.mockk.every
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.core.io.InputStreamResource
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.io.ByteArrayInputStream
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+@ApiTest
+@WebMvcTest(controllers = [MemberProfileEditApi::class])
+class MemberProfileEditApiTest(
+    private val mockMvc: MockMvc,
+    private val mapper: ObjectMapper,
+    @MockkBean private val memberProfileEditService: MemberProfileEditService
+) : BehaviorSpec({
+    Given("유저가") {
+        val id = Arb.long(1L..100L).single()
+        val imageData = "Test image data".toByteArray()
+        val imageResource = InputStreamResource(ByteArrayInputStream(imageData))
+        val profile = MockMultipartFile("profile", "test.jpg", MediaType.IMAGE_JPEG_VALUE, imageResource.inputStream)
+        val fileName = "${LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))}-${UUID.randomUUID()}.jpg"
+        val fileInfo = FileInfo.create("/groubing", fileName, profile.originalFilename)
+
+        When("새로운 프로필 이미지를 등록하는 경우") {
+            every { memberProfileEditService.deleteAndEdit(any(), any()) } returns fileInfo.url
+            val response = MemberProfileResponse(fileInfo.url)
+
+            Then("프로필 이미지 URL 을 응답하도록 한다.") {
+                mockMvc.perform(
+                    multipart("/api/members/{id}/profile", id)
+                        .file(profile)
+                ).andDo(print())
+                    .andExpect(status().isOk)
+                    .andExpect(content().json(mapper.writeValueAsString(ApiResponse.OK(response))))
+                    .andDocument(
+                        "member-profile-edit",
+                        pathVariables(
+                            "id" requestParam "회원 ID" example id.toString()
+                        ),
+                        requestParts(
+                            "profile" requestPart "프로필 이미지 파일" formattedAs ".png / .jpeg / .jpg"
+                        ),
+                        responseBody(
+                            "profileUrl" responseType STRING means "프로필 이미지 URL" example fileInfo.url
+                        )
+                    )
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/beside/groubing/groubingserver/extension/CustomMockMvcRequestBuilders.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/extension/CustomMockMvcRequestBuilders.kt
@@ -1,0 +1,18 @@
+package com.beside.groubing.groubingserver.extension
+
+import org.springframework.http.HttpMethod
+import org.springframework.restdocs.generate.RestDocumentationGenerator
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+
+fun multipart(
+    httpMethod: HttpMethod,
+    urlTemplate: String,
+    vararg urlVariables: Any
+): MockMultipartHttpServletRequestBuilder {
+    return MockMvcRequestBuilders.multipart(httpMethod, urlTemplate, *urlVariables)
+        .requestAttr(
+            RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+            urlTemplate
+        ) as MockMultipartHttpServletRequestBuilder
+}

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
@@ -1,0 +1,12 @@
+|===
+|속성명|데이터 형식|설명|기본값|예시
+
+{{ #parameters }}
+|{{ name }}
+|{{ format }}
+|{{ description }}
+|{{ default }}
+|{{ example }}
+{{ /parameters }}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parts.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parts.snippet
@@ -1,0 +1,12 @@
+|===
+|속성명|데이터 형식|설명|기본값|예시
+
+{{ #requestParts }}
+|{{ name }}
+|{{ format }}
+|{{ description }}
+|{{ default }}
+|{{ example }}
+{{ /requestParts }}
+
+|===


### PR DESCRIPTION
@holeman79 
안녕하세요, 원진님! 테스트 코드 정리를 하느라고 조금 늦었습니다ㅠㅠ
구현한 기능은 다음과 같아요.

- 회원 프로필 수정 API : `POST /api/member/{id}/profile`
- 회원 프로필 삭제 API : `DELETE /api/member/{id}/profile`
- 업로드 파일 조회 API : `GET /api/download/{fileName}`

파일 경로는 추후에 프로필 이미지 뿐만 아니라 빙고 아이템에도 이미지 등록될 수 있는 경우를 고려해 `FILE_INFO` 라는 테이블에서 관리하도록 구현 했습니다. 때문에 `MEMBERS` 테이블과 `FILE_INFOS` 는 연관관계를 맺고 있으며, 프로필 변경 및 삭제 시 기존 연결된 레코드는 삭제하도록 했습니다.

현재 파일은 공통 도메인이라고 생각해서 `/global/domain` 디렉토리에 위치하도록 하고 여러 계층을 모두 `/global/domain/file` 디렉토리 내에 구현 했는데, 이게 과연 좋은 방법인지 확신이 서질 않네요..🥲 해당 부분에 대해서 원진님 의견이 어떠신지 궁금합니다..!

그리고 추가적인 변경사항은 다음과 같습니다.

- `CustomDescriptor.kt` 
  - PathParameters 에 대한 infix 함수명과 구조를 수정했습니다. 이로 인해 해당 infix 함수를 호출하는 코드가 변경되었습니다.
  - RequestParts 에 대한 infix 함수가 추가되었습니다.
- Snippets
  -  PathParameters 스니팻을 오버라이트하는 파일을 추가했습니다. (`path-parameters.snippet`)
  -  RequestParts 스니팻을 오버라이트하는 파일을 추가했습니다. (`request-parts.snippet`)