### PR TITLE
친구 요청 목록 조회 API

### DIFF
--- a/spy.log
+++ b/spy.log
@@ -1,2 +1,3 @@
 1691592172258|0|rollback|connection 5|url jdbc:h2:mem:groubing||
 1691852608837|0|rollback|connection 5|url jdbc:h2:mem:groubing||
+1692533427849|0|rollback|connection 6|url jdbc:h2:mem:groubing||

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/friend/api/FriendFindApi.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/friend/api/FriendFindApi.kt
@@ -1,6 +1,7 @@
 package com.beside.groubing.groubingserver.domain.friend.api
 
 import com.beside.groubing.groubingserver.domain.friend.application.FriendFindService
+import com.beside.groubing.groubingserver.domain.friend.payload.response.FriendRequestResponse
 import com.beside.groubing.groubingserver.domain.friend.payload.response.FriendResponse
 import com.beside.groubing.groubingserver.global.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -17,7 +18,15 @@ class FriendFindApi(
     fun findFriends(
         @AuthenticationPrincipal memberId: Long
     ): ApiResponse<List<FriendResponse>> {
-        val response = friendFindService.findById(memberId)
+        val response = friendFindService.findAllByInviterIdOrInviteeId(memberId)
+        return ApiResponse.OK(response)
+    }
+
+    @GetMapping("/requests")
+    fun findFriendRequests(
+        @AuthenticationPrincipal memberId: Long
+    ): ApiResponse<List<FriendRequestResponse>> {
+        val response = friendFindService.findAllByInviterIdAndLastThreeMonths(memberId)
         return ApiResponse.OK(response)
     }
 }

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/friend/application/FriendFindService.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/friend/application/FriendFindService.kt
@@ -1,6 +1,7 @@
 package com.beside.groubing.groubingserver.domain.friend.application
 
 import com.beside.groubing.groubingserver.domain.friend.dao.FriendFindDao
+import com.beside.groubing.groubingserver.domain.friend.payload.response.FriendRequestResponse
 import com.beside.groubing.groubingserver.domain.friend.payload.response.FriendResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -10,8 +11,13 @@ import org.springframework.transaction.annotation.Transactional
 class FriendFindService(
     private val friendFindDao: FriendFindDao
 ) {
-    fun findById(id: Long): List<FriendResponse> {
-        val friends = friendFindDao.findAllById(id)
+    fun findAllByInviterIdOrInviteeId(memberId: Long): List<FriendResponse> {
+        val friends = friendFindDao.findAllByInviterIdOrInviteeId(memberId)
         return friends.map(::FriendResponse)
+    }
+
+    fun findAllByInviterIdAndLastThreeMonths(inviteeId: Long): List<FriendRequestResponse> {
+        val friendRequestList = friendFindDao.findAllByInviteeIdAndLastThreeMonths(inviteeId)
+        return friendRequestList.map(::FriendRequestResponse)
     }
 }

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/friend/domain/FriendRepository.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/friend/domain/FriendRepository.kt
@@ -2,4 +2,6 @@ package com.beside.groubing.groubingserver.domain.friend.domain
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface FriendRepository : JpaRepository<Friend, Long>
+interface FriendRepository : JpaRepository<Friend, Long> {
+    fun findAllByInviteeId(inviteeId: Long): List<Friend>
+}

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/friend/payload/response/FriendRequestResponse.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/friend/payload/response/FriendRequestResponse.kt
@@ -1,0 +1,22 @@
+package com.beside.groubing.groubingserver.domain.friend.payload.response
+
+import com.beside.groubing.groubingserver.domain.friend.domain.Friend
+import com.beside.groubing.groubingserver.domain.friend.domain.FriendStatus
+
+data class FriendRequestResponse(
+    val id: Long,
+    val inviterId: Long,
+    val email: String,
+    val nickname: String,
+    val profileUrl: String?,
+    val status: FriendStatus
+) {
+    constructor(friendRequest: Friend) : this(
+        friendRequest.id,
+        friendRequest.inviter.id,
+        friendRequest.inviter.email,
+        friendRequest.inviter.nickname,
+        friendRequest.inviter.profile?.url,
+        friendRequest.status
+    )
+}

--- a/src/main/kotlin/com/beside/groubing/groubingserver/domain/friend/payload/response/FriendRequestResponse.kt
+++ b/src/main/kotlin/com/beside/groubing/groubingserver/domain/friend/payload/response/FriendRequestResponse.kt
@@ -5,7 +5,7 @@ import com.beside.groubing.groubingserver.domain.friend.domain.FriendStatus
 
 data class FriendRequestResponse(
     val id: Long,
-    val inviterId: Long,
+    val memberId: Long,
     val email: String,
     val nickname: String,
     val profileUrl: String?,

--- a/src/test/kotlin/com/beside/groubing/groubingserver/domain/friend/api/FriendFindApiTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/domain/friend/api/FriendFindApiTest.kt
@@ -7,6 +7,8 @@ import com.beside.groubing.groubingserver.docs.andDocument
 import com.beside.groubing.groubingserver.docs.responseBody
 import com.beside.groubing.groubingserver.docs.responseType
 import com.beside.groubing.groubingserver.domain.friend.application.FriendFindService
+import com.beside.groubing.groubingserver.domain.friend.domain.FriendStatus
+import com.beside.groubing.groubingserver.domain.friend.payload.response.FriendRequestResponse
 import com.beside.groubing.groubingserver.domain.friend.payload.response.FriendResponse
 import com.beside.groubing.groubingserver.extension.getHttpHeaderJwt
 import com.beside.groubing.groubingserver.global.response.ApiResponse
@@ -17,6 +19,7 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.Codepoint
 import io.kotest.property.arbitrary.alphanumeric
 import io.kotest.property.arbitrary.email
+import io.kotest.property.arbitrary.enum
 import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.of
 import io.kotest.property.arbitrary.single
@@ -35,6 +38,7 @@ class FriendFindApiTest(
     private val mapper: ObjectMapper,
     @MockkBean private val friendFindService: FriendFindService
 ) : BehaviorSpec({
+
     Given("유저가") {
         val id = Arb.long(1L..100L).single()
 
@@ -51,7 +55,7 @@ class FriendFindApiTest(
                 )
             )
             val response = listOf(friend.single())
-            every { friendFindService.findById(any()) } returns response
+            every { friendFindService.findAllByInviterIdOrInviteeId(any()) } returns response
 
             Then("조회한다.") {
                 mockMvc.get("/api/friends") {
@@ -71,6 +75,27 @@ class FriendFindApiTest(
                     )
                 )
             }
+        }
+
+        When("최근 3개월 내 친구 요청 목록을") {
+            val friend = Arb.of(
+                FriendRequestResponse(
+                    id = Arb.long(1L..100L).single(),
+                    inviterId = Arb.long(1L..100L).single(),
+                    email = Arb.email(
+                        Arb.string(5, 10, Codepoint.alphanumeric()),
+                        Arb.stringPattern("groubing\\.com")
+                    ).single(),
+                    nickname = Arb.string(2, 7, codepoints = Codepoint.alphanumeric()).single(),
+                    profileUrl = null,
+                    status = Arb.enum<FriendStatus>().single()
+                )
+            )
+
+            Then("조회한다.") {
+
+            }
+
         }
     }
 })

--- a/src/test/kotlin/com/beside/groubing/groubingserver/domain/friend/dao/FriendFindDaoTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/domain/friend/dao/FriendFindDaoTest.kt
@@ -1,0 +1,56 @@
+package com.beside.groubing.groubingserver.domain.friend.dao
+
+import com.beside.groubing.groubingserver.aMember
+import com.beside.groubing.groubingserver.config.QuerydslConfig
+import com.beside.groubing.groubingserver.domain.friend.domain.Friend
+import com.beside.groubing.groubingserver.domain.friend.domain.FriendRepository
+import com.beside.groubing.groubingserver.domain.friend.domain.FriendStatus
+import com.beside.groubing.groubingserver.domain.member.domain.MemberRepository
+import com.beside.groubing.groubingserver.persistence.LocalPersistenceTest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.set
+import io.kotest.property.arbitrary.single
+import org.springframework.context.annotation.Import
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@LocalPersistenceTest
+@Import(QuerydslConfig::class, FriendFindDao::class)
+class FriendFindDaoTest(
+    private val friendFindDao: FriendFindDao,
+    private val friendRepository: FriendRepository,
+    private val memberRepository: MemberRepository
+) : FunSpec({
+
+    var inviteeId: Long = 0L
+
+    beforeEach {
+        val members = memberRepository.saveAll(
+            Arb.set(Arb.long(1L..100L).map { id -> aMember(id) }, 10..100)
+                .single()
+        )
+        val friends = friendRepository.saveAllAndFlush(
+            (0..<members.size - 1).map { id ->
+                val friend = Friend.create(members[id], members[id + 1])
+                if (id % 2 == 0) friend.status = FriendStatus.ACCEPT
+                friend
+            }
+        )
+        inviteeId = friends.filter { friend -> friend.status.isPending() }.random().invitee.id
+    }
+
+    test("수락한 친구 목록 조회") {
+        val friends = friendFindDao.findAllByInviterIdOrInviteeId(inviteeId)
+        if (inviteeId / 2 == 0L) friends.size shouldBe 1
+        else friends.size shouldBe 0
+    }
+
+    test("모든 친구 요청 목록 조회") {
+        val friendRequests = friendFindDao.findAllByInviteeIdAndLastThreeMonths(inviteeId)
+        friendRequests.size shouldBe 1
+    }
+})

--- a/src/test/kotlin/com/beside/groubing/groubingserver/persistence/LocalPersistenceTest.kt
+++ b/src/test/kotlin/com/beside/groubing/groubingserver/persistence/LocalPersistenceTest.kt
@@ -2,9 +2,11 @@ package com.beside.groubing.groubingserver.persistence
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.test.context.ActiveProfiles
 
 @DataJpaTest
 @ActiveProfiles("local")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EnableJpaAuditing
 annotation class LocalPersistenceTest


### PR DESCRIPTION
@holeman79 
안녕하세요, 원진님!
일전에 민지님께서 요청 주셨던 친구 요청 목록 조회 API 개발 완료하여 PR 올립니다.

요구사항은 다음과 같습니다.
- 현재로부터 3개월 이내의 친구 요청 데이터를 조회한다.
- 친구 요청 처리 상태(`PENDING`, `ACCEPT`, `REJECT`) 와 관계없이 조회한다.

시간 괜찮으실 때 한 번 확인 부탁드립니다~! 
감사합니다🫡