### PR TITLE
feat: ID obfuscator 전 API 적용 (Member / Bingo / Friend / BlockedMember)

### DIFF
--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardDeleteApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardDeleteApi.kt
@@ -1,6 +1,8 @@
 package com.beside.groubing.domain.bingo.api
 
 import com.beside.groubing.domain.bingo.application.BingoBoardDeleteService
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -17,7 +19,7 @@ class BingoBoardDeleteApi(
     fun delete(
         @AuthenticationPrincipal
         memberId: Long,
-        @PathVariable id: Long
+        @PathVariable @DecryptId(ObfuscationType.BINGO_BOARD) id: Long
     ): ApiResponse<Unit> {
         bingoBoardDeleteService.delete(memberId = memberId, boardId = id)
         return ApiResponse.OK(Unit)

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardFindApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardFindApi.kt
@@ -2,6 +2,8 @@ package com.beside.groubing.domain.bingo.api
 
 import com.beside.groubing.domain.bingo.application.BingoBoardFindService
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardDetailResponse
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -15,7 +17,10 @@ class BingoBoardFindApi(
     private val bingoBoardFindService: BingoBoardFindService
 ) {
     @GetMapping("/{id}")
-    fun getBingoBoard(@RequestParam memberId: Long, @PathVariable id: Long): ApiResponse<BingoBoardDetailResponse> {
+    fun getBingoBoard(
+        @RequestParam @DecryptId(ObfuscationType.MEMBER) memberId: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_BOARD) id: Long
+    ): ApiResponse<BingoBoardDetailResponse> {
         val detail = bingoBoardFindService.findOne(memberId, id)
         return ApiResponse.OK(BingoBoardDetailResponse.of(detail))
     }

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardListFindApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardListFindApi.kt
@@ -2,6 +2,8 @@ package com.beside.groubing.domain.bingo.api
 
 import com.beside.groubing.domain.bingo.application.BingoBoardListFindService
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardOverviewResponse
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -16,7 +18,7 @@ class BingoBoardListFindApi(
 ) {
     @GetMapping
     fun findAll(
-        @RequestParam memberId: Long,
+        @RequestParam @DecryptId(ObfuscationType.MEMBER) memberId: Long,
         @AuthenticationPrincipal loginMemberId: Long
     ): ApiResponse<List<BingoBoardOverviewResponse>> {
         val bingoBoards = bingoBoardListFindService.find(memberId, loginMemberId)

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApi.kt
@@ -9,6 +9,8 @@ import com.beside.groubing.domain.bingo.payload.response.BingoBoardBaseUpdateRes
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardMembersPeriodUpdateResponse
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardMemoUpdateResponse
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardOpenUpdateResponse
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -25,7 +27,7 @@ class BingoBoardUpdateApi(
 ) {
     @PatchMapping("/{id}/base")
     fun updateBase(
-        @PathVariable id: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_BOARD) id: Long,
         @AuthenticationPrincipal
         memberId: Long,
         @RequestBody @Valid
@@ -37,7 +39,7 @@ class BingoBoardUpdateApi(
 
     @PatchMapping("/{id}/publish-info")
     fun updateBingoMembersPeriod(
-        @PathVariable id: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_BOARD) id: Long,
         @AuthenticationPrincipal
         memberId: Long,
         @RequestBody @Valid
@@ -49,7 +51,7 @@ class BingoBoardUpdateApi(
 
     @PatchMapping("/{id}/memo")
     fun updateMemo(
-        @PathVariable id: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_BOARD) id: Long,
         @AuthenticationPrincipal
         memberId: Long,
         @RequestBody @Valid
@@ -61,7 +63,7 @@ class BingoBoardUpdateApi(
 
     @PatchMapping("/{id}/open")
     fun updateOpen(
-        @PathVariable id: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_BOARD) id: Long,
         @AuthenticationPrincipal
         memberId: Long,
         @RequestBody @Valid

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemCompleteApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemCompleteApi.kt
@@ -2,6 +2,8 @@ package com.beside.groubing.domain.bingo.api
 
 import com.beside.groubing.domain.bingo.application.BingoItemCompleteService
 import com.beside.groubing.domain.bingo.payload.response.BingoCalculatingResponse
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PatchMapping
@@ -16,8 +18,8 @@ class BingoItemCompleteApi(
 ) {
     @PatchMapping("/{id}/bingo-items/{bingoItemId}/complete")
     fun completeBingoItem(
-        @PathVariable id: Long,
-        @PathVariable bingoItemId: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_BOARD) id: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_ITEM) bingoItemId: Long,
         @AuthenticationPrincipal memberId: Long
     ): ApiResponse<BingoCalculatingResponse> {
         val bingoMap = bingoItemCompleteService.complete(id, bingoItemId, memberId)
@@ -26,8 +28,8 @@ class BingoItemCompleteApi(
 
     @PatchMapping("/{id}/bingo-items/{bingoItemId}/cancel")
     fun cancelBingoItem(
-        @PathVariable id: Long,
-        @PathVariable bingoItemId: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_BOARD) id: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_ITEM) bingoItemId: Long,
         @AuthenticationPrincipal memberId: Long
     ): ApiResponse<BingoCalculatingResponse> {
         val bingoMap = bingoItemCompleteService.cancel(id, bingoItemId, memberId)

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemShuffleApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemShuffleApi.kt
@@ -3,6 +3,8 @@ package com.beside.groubing.domain.bingo.api
 import com.beside.groubing.domain.bingo.application.BingoItemShuffleService
 import com.beside.groubing.domain.bingo.domain.map.Direction
 import com.beside.groubing.domain.bingo.payload.response.BingoLineResponse
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
@@ -17,7 +19,7 @@ class BingoItemShuffleApi(
 ) {
     @PutMapping("/{id}/bingo-items")
     fun shuffle(
-        @PathVariable id: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_BOARD) id: Long,
         @AuthenticationPrincipal memberId: Long,
     ): ApiResponse<List<BingoLineResponse>> {
         val bingoMap = bingoItemShuffleService.shuffle(memberId = memberId, boardId = id)

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemUpdateApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemUpdateApi.kt
@@ -3,6 +3,8 @@ package com.beside.groubing.domain.bingo.api
 import com.beside.groubing.domain.bingo.application.BingoItemUpdateService
 import com.beside.groubing.domain.bingo.payload.request.BingoItemUpdateRequest
 import com.beside.groubing.domain.bingo.payload.response.BingoItemResponse
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -19,8 +21,8 @@ class BingoItemUpdateApi(
 ) {
     @PutMapping("/{id}/bingo-items/{bingoItemId}")
     fun updateBingoItem(
-        @PathVariable id: Long,
-        @PathVariable bingoItemId: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_BOARD) id: Long,
+        @PathVariable @DecryptId(ObfuscationType.BINGO_ITEM) bingoItemId: Long,
         @AuthenticationPrincipal memberId: Long,
         @RequestBody @Valid
         bingoItemUpdateRequest: BingoItemUpdateRequest

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoMemberLeaveApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoMemberLeaveApi.kt
@@ -1,6 +1,8 @@
 package com.beside.groubing.domain.bingo.api
 
 import com.beside.groubing.domain.bingo.application.BingoMemberLeaveService
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,7 +20,7 @@ class BingoMemberLeaveApi(
     fun leave(
         @AuthenticationPrincipal
         memberId: Long,
-        @PathVariable id: Long
+        @PathVariable @DecryptId(ObfuscationType.BINGO_BOARD) id: Long
     ): ApiResponse<Unit> {
         bingoMemberLeaveService.leave(memberId, id)
         return ApiResponse.OK(Unit)

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardBaseUpdateResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardBaseUpdateResponse.kt
@@ -1,9 +1,12 @@
 package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoBoard
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 import java.time.LocalDate
 
 class BingoBoardBaseUpdateResponse private constructor(
+    @EncryptId(ObfuscationType.BINGO_BOARD)
     val id: Long,
     val title: String,
     val goal: Int,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardDetailResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardDetailResponse.kt
@@ -2,9 +2,12 @@ package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoBoardDetail
 import com.beside.groubing.domain.bingo.domain.BingoBoardType
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 import java.time.LocalDate
 
 class BingoBoardDetailResponse private constructor(
+    @EncryptId(ObfuscationType.BINGO_BOARD)
     val id: Long,
 
     val title: String,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMembersPeriodUpdateResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMembersPeriodUpdateResponse.kt
@@ -1,9 +1,12 @@
 package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoBoard
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 import java.time.LocalDate
 
 class BingoBoardMembersPeriodUpdateResponse private constructor(
+    @EncryptId(ObfuscationType.BINGO_BOARD)
     val id: Long,
     val bingoMembers: List<Long>,
     val since: LocalDate?,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMemoUpdateResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMemoUpdateResponse.kt
@@ -1,8 +1,11 @@
 package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoBoard
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 class BingoBoardMemoUpdateResponse private constructor(
+    @EncryptId(ObfuscationType.BINGO_BOARD)
     val id: Long,
     val memo: String?
 ) {

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardOpenUpdateResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardOpenUpdateResponse.kt
@@ -1,8 +1,11 @@
 package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoBoard
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 class BingoBoardOpenUpdateResponse private constructor(
+    @EncryptId(ObfuscationType.BINGO_BOARD)
     val id: Long,
     val open: Boolean
 ) {

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardOverviewResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardOverviewResponse.kt
@@ -5,9 +5,12 @@ import com.beside.groubing.domain.bingo.domain.BingoBoardType
 import com.beside.groubing.domain.bingo.domain.BingoItem
 import com.beside.groubing.domain.bingo.domain.map.BingoLine
 import com.beside.groubing.domain.bingo.domain.map.Direction
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 import java.time.LocalDate
 
 class BingoBoardOverviewResponse private constructor(
+    @EncryptId(ObfuscationType.BINGO_BOARD)
     val id: Long,
 
     val title: String,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardResponse.kt
@@ -3,8 +3,11 @@ package com.beside.groubing.domain.bingo.payload.response
 import com.beside.groubing.domain.bingo.domain.BingoBoard
 import com.beside.groubing.domain.bingo.domain.BingoBoardType
 import com.beside.groubing.domain.bingo.domain.map.Direction
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 class BingoBoardResponse private constructor(
+    @EncryptId(ObfuscationType.BINGO_BOARD)
     val id: Long,
 
     val title: String,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoItemResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoItemResponse.kt
@@ -1,8 +1,11 @@
 package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoItem
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 class BingoItemResponse private constructor(
+    @EncryptId(ObfuscationType.BINGO_ITEM)
     val id: Long,
     val title: String?,
     val subTitle: String?,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/api/UnblockMemberApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/api/UnblockMemberApi.kt
@@ -1,6 +1,8 @@
 package com.beside.groubing.domain.blockedmember.api
 
 import com.beside.groubing.domain.blockedmember.application.UnblockMemberService
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -15,7 +17,7 @@ class UnblockMemberApi(
     @DeleteMapping("/{id}")
     fun unblock(
         @AuthenticationPrincipal memberId: Long,
-        @PathVariable id: Long
+        @PathVariable @DecryptId(ObfuscationType.BLOCKED_MEMBER) id: Long
     ) {
         unblockMemberService.unblock(memberId, id)
     }

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/payload/request/BlockingMemberRequest.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/payload/request/BlockingMemberRequest.kt
@@ -1,10 +1,13 @@
 package com.beside.groubing.domain.blockedmember.payload.request
 
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 
 data class BlockingMemberRequest(
     @field:NotNull(message = "회원 아이디를 입력해 주세요.")
     @field:Min(value = 1L, message = "유효하지 않은 회원 아이디입니다.")
+    @field:EncryptId(ObfuscationType.MEMBER)
     val targetMemberId: Long
 )

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/payload/response/BlockedMemberResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/payload/response/BlockedMemberResponse.kt
@@ -2,8 +2,11 @@ package com.beside.groubing.domain.blockedmember.payload.response
 
 import com.beside.groubing.domain.blockedmember.domain.BlockedMemberTarget
 import com.beside.groubing.global.domain.file.domain.FileInfo
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 data class BlockedMemberResponse(
+    @EncryptId(ObfuscationType.BLOCKED_MEMBER)
     val id: Long,
     val email: String?,
     val nickname: String,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/feed/payload/response/FeedResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/feed/payload/response/FeedResponse.kt
@@ -1,8 +1,11 @@
 package com.beside.groubing.domain.feed.payload.response
 
 import com.beside.groubing.domain.feed.domain.FeedEntry
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 class FeedResponse private constructor(
+    @EncryptId(ObfuscationType.MEMBER)
     val memberId: Long,
 
     val nickname: String,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/api/FriendAcceptApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/api/FriendAcceptApi.kt
@@ -1,6 +1,8 @@
 package com.beside.groubing.domain.friend.api
 
 import com.beside.groubing.domain.friend.application.FriendAcceptService
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -15,7 +17,7 @@ class FriendAcceptApi(
     @PatchMapping("/{id}/accept")
     fun accept(
         @AuthenticationPrincipal memberId: Long,
-        @PathVariable id: Long
+        @PathVariable @DecryptId(ObfuscationType.FRIEND) id: Long
     ) {
         friendAcceptService.accept(memberId = memberId, id = id)
     }

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/api/FriendRejectApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/api/FriendRejectApi.kt
@@ -1,6 +1,8 @@
 package com.beside.groubing.domain.friend.api
 
 import com.beside.groubing.domain.friend.application.FriendRejectService
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -15,7 +17,7 @@ class FriendRejectApi(
     @PatchMapping("/{id}/reject")
     fun reject(
         @AuthenticationPrincipal memberId: Long,
-        @PathVariable id: Long
+        @PathVariable @DecryptId(ObfuscationType.FRIEND) id: Long
     ) {
         friendRejectService.reject(memberId = memberId, id = id)
     }

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/request/FriendAddRequest.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/request/FriendAddRequest.kt
@@ -1,10 +1,13 @@
 package com.beside.groubing.domain.friend.payload.request
 
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 
 data class FriendAddRequest(
     @field:NotNull(message = "회원 아이디를 입력해 주세요.")
     @field:Min(value = 1L, message = "유효하지 않은 회원 아이디입니다.")
+    @field:EncryptId(ObfuscationType.MEMBER)
     val inviteeId: Long
 )

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendRequestResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendRequestResponse.kt
@@ -3,9 +3,12 @@ package com.beside.groubing.domain.friend.payload.response
 import com.beside.groubing.domain.friend.domain.FriendMember
 import com.beside.groubing.domain.friend.domain.FriendStatus
 import com.beside.groubing.global.domain.file.domain.FileInfo
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 data class FriendRequestResponse(
     val id: Long,
+    @EncryptId(ObfuscationType.MEMBER)
     val memberId: Long,
     val email: String?,
     val nickname: String,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendRequestResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendRequestResponse.kt
@@ -7,6 +7,7 @@ import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 data class FriendRequestResponse(
+    @EncryptId(ObfuscationType.FRIEND)
     val id: Long,
     @EncryptId(ObfuscationType.MEMBER)
     val memberId: Long,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendResponse.kt
@@ -6,6 +6,7 @@ import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 data class FriendResponse(
+    @EncryptId(ObfuscationType.FRIEND)
     val id: Long,
     @EncryptId(ObfuscationType.MEMBER)
     val memberId: Long,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendResponse.kt
@@ -2,9 +2,12 @@ package com.beside.groubing.domain.friend.payload.response
 
 import com.beside.groubing.domain.friend.domain.FriendMember
 import com.beside.groubing.global.domain.file.domain.FileInfo
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 data class FriendResponse(
     val id: Long,
+    @EncryptId(ObfuscationType.MEMBER)
     val memberId: Long,
     val email: String?,
     val nickname: String,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberNicknameEditApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberNicknameEditApi.kt
@@ -2,6 +2,8 @@ package com.beside.groubing.domain.member.api
 
 import com.beside.groubing.domain.member.application.MemberNicknameEditService
 import com.beside.groubing.domain.member.payload.request.MemberNicknameEditRequest
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -16,7 +18,7 @@ class MemberNicknameEditApi(
 ) {
     @PatchMapping("/{id}/nickname")
     fun editNickname(
-        @PathVariable id: Long,
+        @PathVariable @DecryptId(ObfuscationType.MEMBER) id: Long,
         @RequestBody
         @Validated
         request: MemberNicknameEditRequest

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberPasswordResetApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberPasswordResetApi.kt
@@ -2,6 +2,8 @@ package com.beside.groubing.domain.member.api
 
 import com.beside.groubing.domain.auth.application.MemberPasswordResetService
 import com.beside.groubing.domain.member.payload.request.MemberPasswordResetRequest
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -16,7 +18,7 @@ class MemberPasswordResetApi(
 ) {
     @PatchMapping("/{id}/password")
     fun resetPassword(
-        @PathVariable id: Long,
+        @PathVariable @DecryptId(ObfuscationType.MEMBER) id: Long,
         @RequestBody
         @Validated
         request: MemberPasswordResetRequest

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberProfileDeleteApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberProfileDeleteApi.kt
@@ -1,6 +1,8 @@
 package com.beside.groubing.domain.member.api
 
 import com.beside.groubing.domain.member.application.MemberProfileDeleteService
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -13,7 +15,7 @@ class MemberProfileDeleteApi(
 ) {
     @DeleteMapping("/{id}/profile")
     fun deleteProfile(
-        @PathVariable id: Long
+        @PathVariable @DecryptId(ObfuscationType.MEMBER) id: Long
     ) {
         memberProfileDeleteService.delete(id)
     }

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberProfileEditApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberProfileEditApi.kt
@@ -3,6 +3,8 @@ package com.beside.groubing.domain.member.api
 import com.beside.groubing.domain.member.application.MemberProfileEditService
 import com.beside.groubing.domain.member.payload.response.MemberProfileResponse
 import com.beside.groubing.global.domain.file.application.FileProvider
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,7 +20,7 @@ class MemberProfileEditApi(
 ) {
     @PatchMapping("/{id}/profile")
     fun editProfile(
-        @PathVariable id: Long,
+        @PathVariable @DecryptId(ObfuscationType.MEMBER) id: Long,
         @RequestPart profile: MultipartFile
     ): ApiResponse<MemberProfileResponse> {
         val newProfile = FileProvider.upload(profile)

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberEmailFindResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberEmailFindResponse.kt
@@ -1,8 +1,11 @@
 package com.beside.groubing.domain.member.payload.response
 
 import com.beside.groubing.domain.member.domain.Member
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 data class MemberEmailFindResponse(
+    @EncryptId(ObfuscationType.MEMBER)
     val id: Long,
     val email: String
 ) {

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberFindResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberFindResponse.kt
@@ -1,8 +1,11 @@
 package com.beside.groubing.domain.member.payload.response
 
 import com.beside.groubing.domain.member.domain.Member
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 class MemberFindResponse(
+    @EncryptId(ObfuscationType.MEMBER)
     val memberId: Long,
     val email: String?,
     val nickname: String,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberResponse.kt
@@ -1,8 +1,11 @@
 package com.beside.groubing.domain.member.payload.response
 
 import com.beside.groubing.domain.auth.domain.AuthenticatedMember
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 data class MemberResponse(
+    @EncryptId(ObfuscationType.MEMBER)
     val id: Long,
     val email: String,
     val nickname: String,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/SocialMemberResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/SocialMemberResponse.kt
@@ -1,8 +1,11 @@
 package com.beside.groubing.domain.member.payload.response
 
 import com.beside.groubing.domain.auth.domain.AuthenticatedMember
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 data class SocialMemberResponse(
+    @EncryptId(ObfuscationType.MEMBER)
     val id: Long,
     val email: String?,
     val nickname: String,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/notification/payload/response/NotificationResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/notification/payload/response/NotificationResponse.kt
@@ -2,10 +2,13 @@ package com.beside.groubing.domain.notification.payload.response
 
 import com.beside.groubing.domain.notification.domain.NotificationItem
 import com.beside.groubing.global.domain.file.domain.FileInfo
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 
 class NotificationResponse(
     val bingoBoardId: Long,
 
+    @EncryptId(ObfuscationType.MEMBER)
     val memberId: Long,
 
     val message: String,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/notification/payload/response/NotificationResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/notification/payload/response/NotificationResponse.kt
@@ -6,6 +6,7 @@ import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 class NotificationResponse(
+    @EncryptId(ObfuscationType.BINGO_BOARD)
     val bingoBoardId: Long,
 
     @EncryptId(ObfuscationType.MEMBER)

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardDeleteApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardDeleteApiTest.kt
@@ -4,7 +4,9 @@ import com.beside.groubing.config.ApiTest
 import com.beside.groubing.docs.andDocument
 import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.domain.bingo.application.BingoBoardDeleteService
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardIdPath
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.FunSpec
@@ -25,10 +27,11 @@ class BingoBoardDeleteApiTest(
     val memberId = 1L
     test("빙고 삭제 Rest Docs Api") {
         val bingoBoardId = 100L
+        val encodedBingoBoardId = bingoBoardId.encodedAs(ObfuscationType.BINGO_BOARD)
         every { bingoBoardDeleteService.delete(memberId = memberId, boardId = bingoBoardId) } returns Unit
 
         mockMvc.perform(
-            RestDocumentationRequestBuilders.delete("/api/bingo-boards/{id}", bingoBoardId)
+            RestDocumentationRequestBuilders.delete("/api/bingo-boards/{id}", encodedBingoBoardId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .header("Authorization", getHttpHeaderJwt(memberId))
@@ -37,7 +40,7 @@ class BingoBoardDeleteApiTest(
             .andDocument(
                 "delete-bingo",
                 pathVariables(
-                    bingoBoardIdPath() example "1" isOptional true
+                    bingoBoardIdPath() example encodedBingoBoardId isOptional true
                 )
             )
     }

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardFindApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardFindApiTest.kt
@@ -9,7 +9,9 @@ import com.beside.groubing.docs.requestParam
 import com.beside.groubing.docs.responseBody
 import com.beside.groubing.domain.bingo.application.BingoBoardFindService
 import com.beside.groubing.domain.bingo.domain.BingoBoardDetail
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardId
 import com.beside.groubing.vocabulary.bingoBoardIdPath
 import com.beside.groubing.vocabulary.bingoBoardType
@@ -60,7 +62,9 @@ class BingoBoardFindApiTest(
         val authentication: Authentication = SecurityContextHolder.getContext().authentication
 
         val memberId = authentication.principal as Long
+        val encodedMemberId = memberId.encodedAs(ObfuscationType.MEMBER)
         val bingoBoardId = 1L
+        val encodedBingoBoardId = bingoBoardId.encodedAs(ObfuscationType.BINGO_BOARD)
         val bingoBoard = aEnglishStudyBingoBoard()
         val member = aMember(memberId).toDomain()
         val otherMembers = (2L..5L).map { aMember(it).toDomain() }
@@ -69,20 +73,20 @@ class BingoBoardFindApiTest(
 
         When("GET /api/bingo-boards/{id} 요청이 들어왔을 때") {
             mockMvc.perform(
-                get("/api/bingo-boards/{id}", bingoBoardId)
+                get("/api/bingo-boards/{id}", encodedBingoBoardId)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
                     .header("Authorization", getHttpHeaderJwt(memberId))
-                    .param("memberId", memberId.toString())
+                    .param("memberId", encodedMemberId)
             ).andDo(print())
                 .andExpect(status().isOk)
                 .andDocument(
                     "bingo-board-find",
                     pathVariables(
-                        bingoBoardIdPath() example "1" isOptional true
+                        bingoBoardIdPath() example encodedBingoBoardId isOptional true
                     ),
                     requestParam(
-                        "memberId" requestParam "회원 ID" example "1"
+                        "memberId" requestParam "회원 ID (obfuscated)" example encodedMemberId
                     ),
                     responseBody(
                         bingoBoardId(),

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardListFindApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardListFindApiTest.kt
@@ -8,7 +8,9 @@ import com.beside.groubing.docs.andDocument
 import com.beside.groubing.docs.requestParam
 import com.beside.groubing.docs.responseBody
 import com.beside.groubing.domain.bingo.application.BingoBoardListFindService
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardId
 import com.beside.groubing.vocabulary.bingoBoardType
 import com.beside.groubing.vocabulary.bingoColorValue
@@ -42,6 +44,7 @@ class BingoBoardListFindApiTest(
 ) : BehaviorSpec({
     Given("BingoBoardListFindApi가 주어졌을 때") {
         val memberId = 1L
+        val encodedMemberId = memberId.encodedAs(ObfuscationType.MEMBER)
         val loginMemberId = 2L
 
         val bingoBoards = listOf(
@@ -62,14 +65,14 @@ class BingoBoardListFindApiTest(
                 get("/api/bingo-boards")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
-                    .param("memberId", "1")
+                    .param("memberId", encodedMemberId)
                     .header("Authorization", getHttpHeaderJwt(loginMemberId))
             ).andDo(print())
                 .andExpect(status().isOk)
                 .andDocument(
                     "bingo-board-list-find",
                     requestParam(
-                        "memberId" requestParam "멤버 ID" example "1" isOptional true
+                        "memberId" requestParam "멤버 ID (obfuscated)" example encodedMemberId isOptional true
                     ),
                     responseBody(
                         bingoBoardId("[].id"),

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApiTest.kt
@@ -20,7 +20,9 @@ import com.beside.groubing.domain.bingo.payload.response.BingoBoardBaseUpdateRes
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardMembersPeriodUpdateResponse
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardMemoUpdateResponse
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardOpenUpdateResponse
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.global.response.ApiResponse
 import com.beside.groubing.vocabulary.bingoBoardId
 import com.beside.groubing.vocabulary.bingoGoal
@@ -51,6 +53,7 @@ class BingoBoardUpdateApiTest(
     Given("빙고 업데이트 API가 주어졌을 때") {
         val aEmptyBingo = aEmptyBingo()
         val id = aEmptyBingo.id
+        val encodedId = id.encodedAs(ObfuscationType.BINGO_BOARD)
         val memberId = 1L
 
         val bingoBoardBaseUpdateRequest = BingoBoardBaseUpdateRequest(
@@ -70,7 +73,7 @@ class BingoBoardUpdateApiTest(
                 mockMvc,
                 mapper,
                 "/api/bingo-boards/{id}/base",
-                id,
+                encodedId,
                 memberId,
                 bingoBoardBaseUpdateRequest,
                 ApiResponse.OK(BingoBoardBaseUpdateResponse.fromBingoBoard(aEmptyBingo)),
@@ -99,7 +102,7 @@ class BingoBoardUpdateApiTest(
                 mockMvc,
                 mapper,
                 "/api/bingo-boards/{id}/memo",
-                id,
+                encodedId,
                 memberId,
                 bingoBoardMemoUpdateRequest,
                 ApiResponse.OK(BingoBoardMemoUpdateResponse.fromBingoBoard(aEmptyBingo)),
@@ -122,7 +125,7 @@ class BingoBoardUpdateApiTest(
                 mockMvc,
                 mapper,
                 "/api/bingo-boards/{id}/open",
-                id,
+                encodedId,
                 memberId,
                 bingoBoardOpenUpdateRequest,
                 ApiResponse.OK(BingoBoardOpenUpdateResponse.fromBingoBoard(aEmptyBingo)),
@@ -160,7 +163,7 @@ class BingoBoardUpdateApiTest(
                 mockMvc,
                 mapper,
                 "/api/bingo-boards/{id}/publish-info",
-                id,
+                encodedId,
                 memberId,
                 bingoBoardMembersPeriodUpdateRequest,
                 ApiResponse.OK(BingoBoardMembersPeriodUpdateResponse.fromBingoBoard(aEmptyBingo)),
@@ -185,7 +188,7 @@ private fun checkUpdateResponse(
     mockMvc: MockMvc,
     mapper: ObjectMapper,
     url: String,
-    bingoBoardId: Long,
+    bingoBoardId: String,
     memberId: Long,
     request: Any,
     expectedResponse: ApiResponse<*>,

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemCompleteApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemCompleteApiTest.kt
@@ -7,7 +7,9 @@ import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.docs.requestParam
 import com.beside.groubing.docs.responseBody
 import com.beside.groubing.domain.bingo.application.BingoItemCompleteService
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardIdPath
 import com.beside.groubing.vocabulary.diagonalBingoIndexes
 import com.beside.groubing.vocabulary.horizontalBingoIndexes
@@ -33,6 +35,8 @@ class BingoItemCompleteApiTest(
         val englishBingoBoard = aEnglishStudyBingoBoard()
         val memberId = 1L
         val bingoItem = englishBingoBoard.bingoItems[0]
+        val encodedBingoBoardId = englishBingoBoard.id.encodedAs(ObfuscationType.BINGO_BOARD)
+        val encodedBingoItemId = bingoItem.id.encodedAs(ObfuscationType.BINGO_ITEM)
         val bingoMap = englishBingoBoard.makeBingoMap(memberId)
         every { bingoItemCompleteService.complete(englishBingoBoard.id, bingoItem.id, memberId) } returns bingoMap
 
@@ -47,8 +51,8 @@ class BingoItemCompleteApiTest(
             mockMvc.perform(
                 RestDocumentationRequestBuilders.patch(
                     "/api/bingo-boards/{id}/bingo-items/{bingoItemId}/complete",
-                    englishBingoBoard.id,
-                    bingoItem.id
+                    encodedBingoBoardId,
+                    encodedBingoItemId
                 )
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
@@ -58,8 +62,8 @@ class BingoItemCompleteApiTest(
                 .andDocument(
                     "bingo-item-complete",
                     pathVariables(
-                        bingoBoardIdPath() example "1" isOptional true,
-                        "bingoItemId" requestParam "빙고 아이템 ID" example "1" isOptional true
+                        bingoBoardIdPath() example encodedBingoBoardId isOptional true,
+                        "bingoItemId" requestParam "빙고 아이템 ID (obfuscated)" example encodedBingoItemId isOptional true
                     ),
                     responseBody
                 )
@@ -70,8 +74,8 @@ class BingoItemCompleteApiTest(
             mockMvc.perform(
                 RestDocumentationRequestBuilders.patch(
                     "/api/bingo-boards/{id}/bingo-items/{bingoItemId}/cancel",
-                    englishBingoBoard.id,
-                    bingoItem.id
+                    encodedBingoBoardId,
+                    encodedBingoItemId
                 )
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
@@ -81,8 +85,8 @@ class BingoItemCompleteApiTest(
                 .andDocument(
                     "bingo-item-cancel",
                     pathVariables(
-                        bingoBoardIdPath() example "1" isOptional true,
-                        "bingoItemId" requestParam "빙고 아이템 ID" example "1" isOptional true
+                        bingoBoardIdPath() example encodedBingoBoardId isOptional true,
+                        "bingoItemId" requestParam "빙고 아이템 ID (obfuscated)" example encodedBingoItemId isOptional true
                     ),
                     responseBody
                 )

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemShuffleApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemShuffleApiTest.kt
@@ -6,7 +6,9 @@ import com.beside.groubing.docs.andDocument
 import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.docs.responseBody
 import com.beside.groubing.domain.bingo.application.BingoItemShuffleService
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardIdPath
 import com.beside.groubing.vocabulary.bingoItemColorCode
 import com.beside.groubing.vocabulary.bingoItemComplete
@@ -37,6 +39,7 @@ class BingoItemShuffleApiTest(
 
         val temporaryBingo = aTemporaryBingo()
         temporaryBingo.shuffleBingoItems()
+        val encodedBingoBoardId = temporaryBingo.id.encodedAs(ObfuscationType.BINGO_BOARD)
         val bingoMap = temporaryBingo.makeBingoMap(memberId)
 
         every { bingoItemShuffleService.shuffle(memberId = memberId, boardId = temporaryBingo.id) } returns bingoMap
@@ -45,7 +48,7 @@ class BingoItemShuffleApiTest(
             mockMvc.perform(
                 RestDocumentationRequestBuilders.put(
                     "/api/bingo-boards/{id}/bingo-items",
-                    temporaryBingo.id
+                    encodedBingoBoardId
                 )
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
@@ -55,7 +58,7 @@ class BingoItemShuffleApiTest(
                 .andDocument(
                     "bingo-item-shuffle",
                     pathVariables(
-                        bingoBoardIdPath() example "1" isOptional true
+                        bingoBoardIdPath() example encodedBingoBoardId isOptional true
                     ),
                     responseBody(
                         bingoLineDirection("[].direction"),

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemUpdateApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemUpdateApiTest.kt
@@ -11,7 +11,9 @@ import com.beside.groubing.docs.requestType
 import com.beside.groubing.docs.responseBody
 import com.beside.groubing.domain.bingo.application.BingoItemUpdateService
 import com.beside.groubing.domain.bingo.payload.request.BingoItemUpdateRequest
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardIdPath
 import com.beside.groubing.vocabulary.bingoItemColorCode
 import com.beside.groubing.vocabulary.bingoItemComplete
@@ -46,14 +48,16 @@ class BingoItemUpdateApiTest(
             subTitle = "8월까지 끝내기"
         )
         val bingoItem = aEmptyBingo.bingoItems[0]
+        val encodedBingoBoardId = aEmptyBingo.id.encodedAs(ObfuscationType.BINGO_BOARD)
+        val encodedBingoItemId = bingoItem.id.encodedAs(ObfuscationType.BINGO_ITEM)
         every { bingoItemUpdateService.update(aEmptyBingo.id, bingoItem.id, memberId, any()) } returns bingoItem
 
         When("데이터가 유효하다면") {
             mockMvc.perform(
                 RestDocumentationRequestBuilders.put(
                     "/api/bingo-boards/{id}/bingo-items/{bingoItemId}",
-                    aEmptyBingo.id,
-                    bingoItem.id
+                    encodedBingoBoardId,
+                    encodedBingoItemId
                 )
                     .content(mapper.writeValueAsString(request))
                     .contentType(MediaType.APPLICATION_JSON)
@@ -64,8 +68,8 @@ class BingoItemUpdateApiTest(
                 .andDocument(
                     "bingo-item-update",
                     pathVariables(
-                        bingoBoardIdPath() example "1" isOptional true,
-                        "bingoItemId" requestParam "빙고 아이템 ID" example "1" isOptional true
+                        bingoBoardIdPath() example encodedBingoBoardId isOptional true,
+                        "bingoItemId" requestParam "빙고 아이템 ID (obfuscated)" example encodedBingoItemId isOptional true
                     ),
                     requestBody(
                         "title" requestType STRING means "빙고 아이템 제목" example request.title,

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/BlockMemberApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/BlockMemberApiTest.kt
@@ -1,13 +1,15 @@
 package com.beside.groubing.domain.blockedmember.api
 
 import com.beside.groubing.config.ApiTest
-import com.beside.groubing.docs.NUMBER
+import com.beside.groubing.docs.STRING
 import com.beside.groubing.docs.andDocument
 import com.beside.groubing.docs.requestBody
 import com.beside.groubing.docs.requestType
 import com.beside.groubing.domain.blockedmember.application.BlockMemberService
 import com.beside.groubing.domain.blockedmember.payload.request.BlockingMemberRequest
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
@@ -43,7 +45,11 @@ class BlockMemberApiTest(
                 }.andExpect { status { isOk() } }
                     .andDocument(
                         "block-member",
-                        requestBody("targetMemberId" requestType NUMBER means "친구 요청할 유저 ID" example request.targetMemberId.toString())
+                        requestBody(
+                            "targetMemberId" requestType STRING means
+                                "차단할 유저 ID (obfuscated)" example
+                                request.targetMemberId.encodedAs(ObfuscationType.MEMBER)
+                        )
                     )
             }
         }

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/BlockedMemberFindApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/BlockedMemberFindApiTest.kt
@@ -8,8 +8,8 @@ import com.beside.groubing.domain.blockedmember.domain.BlockedMemberTarget
 import com.beside.groubing.domain.blockedmember.payload.response.BlockedMemberResponse
 import com.beside.groubing.extension.getHttpHeaderJwt
 import com.beside.groubing.global.response.ApiResponse
+import com.beside.groubing.vocabulary.blockedMemberId
 import com.beside.groubing.vocabulary.email
-import com.beside.groubing.vocabulary.id
 import com.beside.groubing.vocabulary.nickname
 import com.beside.groubing.vocabulary.profileUrl
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -64,7 +64,7 @@ class BlockedMemberFindApiTest(
                 }.andDocument(
                     "blocked-member-find",
                     responseBody(
-                        id("[].id", "유저 ID"),
+                        blockedMemberId("[].id"),
                         email("[].email"),
                         nickname("[].nickname"),
                         profileUrl("[].profileUrl"),

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/UnblockMemberApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/UnblockMemberApiTest.kt
@@ -4,8 +4,10 @@ import com.beside.groubing.config.ApiTest
 import com.beside.groubing.docs.andDocument
 import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.domain.blockedmember.application.UnblockMemberService
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.vocabulary.idPath
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.vocabulary.blockedMemberIdPath
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.property.Arb
@@ -26,6 +28,7 @@ class UnblockMemberApiTest(
 ) : BehaviorSpec({
     Given("유저가") {
         val id = Arb.long(1L..100L).single()
+        val encodedId = id.encodedAs(ObfuscationType.BLOCKED_MEMBER)
         val userId = Arb.long(1L..100L).single()
 
         When("특정 유저를") {
@@ -33,14 +36,14 @@ class UnblockMemberApiTest(
 
             Then("차단 해제한다.") {
                 mockMvc.perform(
-                    delete("/api/blocked-members/{id}", id)
+                    delete("/api/blocked-members/{id}", encodedId)
                         .header("Authorization", getHttpHeaderJwt(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                 ).andExpect(status().isOk)
                     .andDocument(
                         "unblock-member",
-                        pathVariables(idPath("id", "회원 차단 내역 ID") example id.toString())
+                        pathVariables(blockedMemberIdPath() example encodedId)
                     )
             }
         }

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendAcceptApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendAcceptApiTest.kt
@@ -4,7 +4,9 @@ import com.beside.groubing.config.ApiTest
 import com.beside.groubing.docs.andDocument
 import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.domain.friend.application.FriendAcceptService
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.vocabulary.friendIdPath
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
@@ -26,6 +28,7 @@ class FriendAcceptApiTest(
 ) : BehaviorSpec({
     Given("유저가") {
         val id = Arb.long(1L..100L).single()
+        val encodedId = id.encodedAs(ObfuscationType.FRIEND)
         val userId = Arb.long(1L..100L).single()
 
         When("친구 요청을") {
@@ -34,14 +37,14 @@ class FriendAcceptApiTest(
                 justRun { friendAcceptService.accept(any(), any()) }
 
                 mockMvc.perform(
-                    patch("/api/friends/{id}/accept", id)
+                    patch("/api/friends/{id}/accept", encodedId)
                         .header("Authorization", getHttpHeaderJwt(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                 ).andExpect(status().isOk)
                     .andDocument(
                         "friend-accept",
-                        pathVariables(friendIdPath() example id.toString())
+                        pathVariables(friendIdPath() example encodedId)
                     )
             }
         }

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendAddApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendAddApiTest.kt
@@ -1,13 +1,15 @@
 package com.beside.groubing.domain.friend.api
 
 import com.beside.groubing.config.ApiTest
-import com.beside.groubing.docs.NUMBER
+import com.beside.groubing.docs.STRING
 import com.beside.groubing.docs.andDocument
 import com.beside.groubing.docs.requestBody
 import com.beside.groubing.docs.requestType
 import com.beside.groubing.domain.friend.application.FriendAddService
 import com.beside.groubing.domain.friend.payload.request.FriendAddRequest
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
@@ -43,7 +45,11 @@ class FriendAddApiTest(
                 }.andExpect { status { isOk() } }
                     .andDocument(
                         "friend-add",
-                        requestBody("inviteeId" requestType NUMBER means "친구 요청할 유저 ID" example request.inviteeId.toString())
+                        requestBody(
+                            "inviteeId" requestType STRING means
+                                "친구 요청할 유저 ID (obfuscated)" example
+                                request.inviteeId.encodedAs(ObfuscationType.MEMBER)
+                        )
                     )
             }
         }

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendRejectApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendRejectApiTest.kt
@@ -4,7 +4,9 @@ import com.beside.groubing.config.ApiTest
 import com.beside.groubing.docs.andDocument
 import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.domain.friend.application.FriendRejectService
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.vocabulary.friendIdPath
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
@@ -26,6 +28,7 @@ class FriendRejectApiTest(
 ) : BehaviorSpec({
     Given("유저가") {
         val id = Arb.long(1L..100L).single()
+        val encodedId = id.encodedAs(ObfuscationType.FRIEND)
         val userId = Arb.long(1L..100L).single()
 
         When("친구 요청을") {
@@ -34,14 +37,14 @@ class FriendRejectApiTest(
                 justRun { friendRejectService.reject(any(), any()) }
 
                 mockMvc.perform(
-                    patch("/api/friends/{id}/reject", id)
+                    patch("/api/friends/{id}/reject", encodedId)
                         .header("Authorization", getHttpHeaderJwt(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                 ).andExpect(status().isOk)
                     .andDocument(
                         "friend-reject",
-                        pathVariables(friendIdPath() example id.toString())
+                        pathVariables(friendIdPath() example encodedId)
                     )
             }
         }

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberNicknameEditApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberNicknameEditApiTest.kt
@@ -8,7 +8,9 @@ import com.beside.groubing.docs.requestBody
 import com.beside.groubing.docs.requestType
 import com.beside.groubing.domain.member.application.MemberNicknameEditService
 import com.beside.groubing.domain.member.payload.request.MemberNicknameEditRequest
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.vocabulary.memberIdPath
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
@@ -37,6 +39,7 @@ class MemberNicknameEditApiTest(
 ) : BehaviorSpec({
     Given("유저가") {
         val id = Arb.long(min = 1L, max = 100L).single()
+        val encodedId = id.encodedAs(ObfuscationType.MEMBER)
         val nickname = Arb.string(2, 7, codepoints = Codepoint.alphanumeric()).single()
         val request = MemberNicknameEditRequest(nickname)
 
@@ -45,7 +48,7 @@ class MemberNicknameEditApiTest(
 
             Then("성공 응답을 리턴한다.") {
                 mockMvc.perform(
-                    patch("/api/members/{id}/nickname", id)
+                    patch("/api/members/{id}/nickname", encodedId)
                         .header("Authorization", getHttpHeaderJwt(id))
                         .content(mapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -54,7 +57,7 @@ class MemberNicknameEditApiTest(
                     .andDocument(
                         "member-nickname-edit",
                         pathVariables(
-                            memberIdPath() example id.toString() isOptional true
+                            memberIdPath() example encodedId isOptional true
                         ),
                         requestBody(
                             "nickname" requestType STRING means "닉네임" example nickname formattedAs "^[가-힣a-zA-Z0-9]{2,7}"

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberPasswordResetApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberPasswordResetApiTest.kt
@@ -9,7 +9,9 @@ import com.beside.groubing.docs.requestType
 import com.beside.groubing.domain.auth.application.MemberPasswordResetService
 import com.beside.groubing.vocabulary.memberIdPath
 import com.beside.groubing.domain.member.payload.request.MemberPasswordResetRequest
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
@@ -37,6 +39,7 @@ class MemberPasswordResetApiTest(
 ) : BehaviorSpec({
     Given("유저가") {
         val id = Arb.long(min = 1L, max = 100L).single()
+        val encodedId = id.encodedAs(ObfuscationType.MEMBER)
         val beforePassword = Arb.string(8, 20, codepoints = Codepoint.alphanumeric()).single()
         val afterPassword = Arb.string(8, 20, codepoints = Codepoint.alphanumeric()).single()
         val request = MemberPasswordResetRequest(beforePassword, afterPassword)
@@ -46,7 +49,7 @@ class MemberPasswordResetApiTest(
 
             Then("성공 응답을 리턴한다.") {
                 mockMvc.perform(
-                    patch("/api/members/{id}/password", id)
+                    patch("/api/members/{id}/password", encodedId)
                         .header("Authorization", getHttpHeaderJwt(id))
                         .content(mapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -55,7 +58,7 @@ class MemberPasswordResetApiTest(
                     .andDocument(
                         "member-password-reset",
                         pathVariables(
-                            memberIdPath() example id.toString() isOptional true
+                            memberIdPath() example encodedId isOptional true
                         ),
                         requestBody(
                             "beforePassword" requestType STRING means "이전에 사용한 패스워드" example beforePassword,

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberProfileDeleteApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberProfileDeleteApiTest.kt
@@ -4,6 +4,8 @@ import com.beside.groubing.config.ApiTest
 import com.beside.groubing.docs.andDocument
 import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.domain.member.application.MemberProfileDeleteService
+import com.beside.groubing.extension.encodedAs
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.vocabulary.memberIdPath
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
@@ -25,18 +27,19 @@ class MemberProfileDeleteApiTest(
 ) : BehaviorSpec({
     Given("유저가") {
         val id = Arb.long(1L..100L).single()
+        val encodedId = id.encodedAs(ObfuscationType.MEMBER)
 
         When("기존에 등록한 프로필 이미지를 삭제할 경우") {
             justRun { memberProfileDeleteService.delete(any()) }
 
             Then("성공 응답을 리턴한다.") {
-                mockMvc.perform(delete("/api/members/{id}/profile", id))
+                mockMvc.perform(delete("/api/members/{id}/profile", encodedId))
                     .andDo(print())
                     .andExpect(status().isOk)
                     .andDocument(
                         "member-profile-delete",
                         pathVariables(
-                            memberIdPath() example id.toString()
+                            memberIdPath() example encodedId
                         )
                     )
             }

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberProfileEditApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberProfileEditApiTest.kt
@@ -10,9 +10,11 @@ import com.beside.groubing.domain.member.application.MemberProfileEditService
 import com.beside.groubing.vocabulary.memberIdPath
 import com.beside.groubing.vocabulary.profileUrl
 import com.beside.groubing.domain.member.payload.response.MemberProfileResponse
+import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.multipart
 import com.beside.groubing.global.domain.file.application.FileProvider
 import com.beside.groubing.global.domain.file.domain.FileInfo
+import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.global.response.ApiResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
@@ -49,6 +51,7 @@ class MemberProfileEditApiTest(
 
     Given("유저가") {
         val id = Arb.long(1L..100L).single()
+        val encodedId = id.encodedAs(ObfuscationType.MEMBER)
         val imageData = "Test image data".toByteArray()
         val imageResource = InputStreamResource(ByteArrayInputStream(imageData))
         val profile = MockMultipartFile("profile", "test.jpg", MediaType.IMAGE_JPEG_VALUE, imageResource.inputStream)
@@ -62,7 +65,7 @@ class MemberProfileEditApiTest(
 
             Then("프로필 이미지 URL 을 응답하도록 한다.") {
                 mockMvc.perform(
-                    multipart(HttpMethod.PATCH, "/api/members/{id}/profile", id)
+                    multipart(HttpMethod.PATCH, "/api/members/{id}/profile", encodedId)
                         .file(profile)
                 ).andDo(print())
                     .andExpect(status().isOk)
@@ -70,7 +73,7 @@ class MemberProfileEditApiTest(
                     .andDocument(
                         "member-profile-edit",
                         pathVariables(
-                            memberIdPath() example id.toString()
+                            memberIdPath() example encodedId
                         ),
                         requestParts(
                             "profile" requestPart "프로필 이미지 파일" formattedAs ".png / .jpeg / .jpg"

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/extension/IdObfuscatorExpression.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/extension/IdObfuscatorExpression.kt
@@ -3,17 +3,7 @@ package com.beside.groubing.extension
 import com.beside.groubing.global.domain.id.ObfuscationType
 import com.beside.groubing.global.support.id.HashidsIdObfuscator
 
-/**
- * 테스트 전용 ID 인코딩 헬퍼.
- *
- * `TestIdObfuscatorConfig` 가 빈으로 등록한 [HashidsIdObfuscator] 와 동일한 salt 를 써서
- * MockMvc 요청 URL 에 넣을 obfuscated 문자열을 만든다. 사용 예:
- *
- * ```kotlin
- * val id = 1L
- * patch("/api/members/{id}/nickname", id.encodedAs(ObfuscationType.MEMBER))
- * ```
- */
+/** `TestIdObfuscatorConfig` 와 동일 salt — MockMvc URL 에 넣을 obfuscated 문자열 생성. */
 private val testIdObfuscator = HashidsIdObfuscator(
     baseSalt = "test-salt",
     minLength = 12

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/extension/IdObfuscatorExpression.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/extension/IdObfuscatorExpression.kt
@@ -1,0 +1,22 @@
+package com.beside.groubing.extension
+
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.support.id.HashidsIdObfuscator
+
+/**
+ * 테스트 전용 ID 인코딩 헬퍼.
+ *
+ * `TestIdObfuscatorConfig` 가 빈으로 등록한 [HashidsIdObfuscator] 와 동일한 salt 를 써서
+ * MockMvc 요청 URL 에 넣을 obfuscated 문자열을 만든다. 사용 예:
+ *
+ * ```kotlin
+ * val id = 1L
+ * patch("/api/members/{id}/nickname", id.encodedAs(ObfuscationType.MEMBER))
+ * ```
+ */
+private val testIdObfuscator = HashidsIdObfuscator(
+    baseSalt = "test-salt",
+    minLength = 12
+)
+
+fun Long.encodedAs(type: ObfuscationType): String = testIdObfuscator.encode(type, this)

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/BingoVocabulary.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/BingoVocabulary.kt
@@ -14,12 +14,12 @@ import com.beside.groubing.domain.bingo.domain.map.Direction
 // --- Path / Query ---
 
 fun bingoBoardIdPath(fieldName: String = "id") =
-    fieldName requestParam "빙고 ID"
+    fieldName requestParam "빙고 ID (obfuscated)"
 
 // --- BingoBoard 응답 ---
 
 fun bingoBoardId(fieldName: String = "id") =
-    fieldName responseType NUMBER means "빙고 ID" example "1"
+    fieldName responseType STRING means "빙고 ID (obfuscated)" example "MEbN4aLpqRzK"
 
 fun bingoTitle(fieldName: String = "title") =
     fieldName responseType STRING means
@@ -87,7 +87,7 @@ fun bingoLineDirection(fieldName: String) =
         "X : `HORIZONTAL`, Y : `VERTICAL`, Z : `DIAGONAL`"
 
 fun bingoItemId(fieldName: String) =
-    fieldName responseType NUMBER means "빙고 아이템 ID" example "1"
+    fieldName responseType STRING means "빙고 아이템 ID (obfuscated)" example "MEbN4aLpqRzK"
 
 fun bingoItemTitle(fieldName: String) =
     fieldName responseType STRING means "TODO" example "토익 만점 받기"

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/BlockedMemberVocabulary.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/BlockedMemberVocabulary.kt
@@ -1,0 +1,11 @@
+package com.beside.groubing.vocabulary
+
+import com.beside.groubing.docs.STRING
+import com.beside.groubing.docs.requestParam
+import com.beside.groubing.docs.responseType
+
+fun blockedMemberId(fieldName: String = "id", description: String = "차단 ID (obfuscated)") =
+    fieldName responseType STRING means description example "MEbN4aLpqRzK"
+
+fun blockedMemberIdPath(fieldName: String = "id") =
+    fieldName requestParam "차단 ID (obfuscated)"

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/FriendVocabulary.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/FriendVocabulary.kt
@@ -1,13 +1,13 @@
 package com.beside.groubing.vocabulary
 
 import com.beside.groubing.docs.ENUM
-import com.beside.groubing.docs.NUMBER
+import com.beside.groubing.docs.STRING
 import com.beside.groubing.docs.requestParam
 import com.beside.groubing.docs.responseType
 import com.beside.groubing.domain.friend.domain.FriendStatus
 
-fun friendId(fieldName: String = "id", description: String = "친구 요청 ID") =
-    fieldName responseType NUMBER means description example "1"
+fun friendId(fieldName: String = "id", description: String = "친구 요청 ID (obfuscated)") =
+    fieldName responseType STRING means description example "MEbN4aLpqRzK"
 
 fun friendStatus(fieldName: String = "status") =
     fieldName responseType ENUM(FriendStatus::class) means
@@ -15,4 +15,4 @@ fun friendStatus(fieldName: String = "status") =
         "`PENDING` : 친구 요청 / `ACCEPT` : 수락 / `REJECT` : 거절"
 
 fun friendIdPath(fieldName: String = "id") =
-    fieldName requestParam "친구 요청 ID"
+    fieldName requestParam "친구 요청 ID (obfuscated)"

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/MemberVocabulary.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/MemberVocabulary.kt
@@ -2,7 +2,6 @@ package com.beside.groubing.vocabulary
 
 import com.beside.groubing.docs.BOOLEAN
 import com.beside.groubing.docs.ENUM
-import com.beside.groubing.docs.NUMBER
 import com.beside.groubing.docs.STRING
 import com.beside.groubing.docs.requestParam
 import com.beside.groubing.docs.responseType
@@ -12,15 +11,15 @@ import com.beside.groubing.domain.member.domain.MemberType
 // --- Path Variable ---
 
 fun memberIdPath(fieldName: String = "id") =
-    fieldName requestParam "유저 ID"
+    fieldName requestParam "유저 ID (obfuscated)"
 
-// --- 회원 식별자 ---
+// --- 회원 식별자 (obfuscated 문자열) ---
 
-fun memberId(fieldName: String = "memberId", description: String = "회원 ID") =
-    fieldName responseType NUMBER means description example "1"
+fun memberId(fieldName: String = "memberId", description: String = "회원 ID (obfuscated)") =
+    fieldName responseType STRING means description example "MEbN4aLpqRzK"
 
-fun targetMemberId(fieldName: String = "targetMemberId", description: String = "대상 회원 ID") =
-    fieldName responseType NUMBER means description example "1"
+fun targetMemberId(fieldName: String = "targetMemberId", description: String = "대상 회원 ID (obfuscated)") =
+    fieldName responseType STRING means description example "MEbN4aLpqRzK"
 
 // --- 회원 프로필 ---
 

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/NotificationVocabulary.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/NotificationVocabulary.kt
@@ -1,11 +1,10 @@
 package com.beside.groubing.vocabulary
 
-import com.beside.groubing.docs.NUMBER
 import com.beside.groubing.docs.STRING
 import com.beside.groubing.docs.responseType
 
 fun notificationBingoBoardId(fieldName: String = "bingoBoardId") =
-    fieldName responseType NUMBER means "빙고보드 ID" example "1"
+    fieldName responseType STRING means "빙고보드 ID (obfuscated)" example "MEbN4aLpqRzK"
 
 fun notificationMessage(fieldName: String = "message") =
     fieldName responseType STRING means "알림 메세지" example "awaji님이 이직 준비하기 빙고의 목표 빙고 수를 달성했어요!"


### PR DESCRIPTION
## 개요

Phase 1 인프라(#16) 위에 모든 도메인의 응답·요청·컨트롤러에 `@EncryptId` / `@DecryptId` 를 부착해 외부 노출 id 를 obfuscated 문자열로 전환한다.

**Base 브랜치는 `feat/id-obfuscator`** — Phase 1 인프라 PR(#16) 머지 후 dev 로 base 변경 또는 그대로 머지.

> ⚠️ **Breaking change**: 모든 API 응답·요청의 `*Id: Long` 필드 / path-variable / query-param 이 NUMBER → STRING 으로 바뀐다. 프론트엔드(groubing-app-frontend) 도 같이 갱신 필요.

## 도메인별 커밋 (4개)

- `0695687` **Member 도메인** (+ cross-domain `memberId` 필드)
  - MemberVocabulary STRING 화, Member 응답 4개 + Friend/Feed/Notification 의 `memberId` 에 `@EncryptId(MEMBER)`.
  - Member API 4개에 `@PathVariable @DecryptId(MEMBER)`.
  - 테스트 헬퍼 `Long.encodedAs(ObfuscationType)` 신규.

- `eb5fed9` **Bingo 도메인** (BingoBoard / BingoItem)
  - BingoBoard 응답 7개에 `@EncryptId(BINGO_BOARD)`, BingoItemResponse 에 `@EncryptId(BINGO_ITEM)`.
  - NotificationResponse.bingoBoardId 에 `@EncryptId(BINGO_BOARD)` (cross-domain).
  - Bingo API 7개 + BingoBoardListFindApi 의 `@RequestParam memberId` 에 `@DecryptId`.

- `f8f2077` **Friend 도메인**
  - friendId STRING 화, FriendResponse/FriendRequestResponse 에 `@EncryptId(FRIEND)`.
  - FriendAccept/Reject 에 `@DecryptId(FRIEND)`, FriendAddRequest.inviteeId 에 `@field:EncryptId(MEMBER)`.

- `1bbc782` **BlockedMember 도메인**
  - BlockedMemberVocabulary 신규.
  - BlockedMemberResponse.id 에 `@EncryptId(BLOCKED_MEMBER)`.
  - UnblockMemberApi 에 `@DecryptId(BLOCKED_MEMBER)`, BlockingMemberRequest.targetMemberId 에 `@field:EncryptId(MEMBER)`.

## 변환 패턴 (검증된 규칙)

| 위치 | 변환 |
|---|---|
| 응답 DTO `*Id: Long` 필드 | `@EncryptId(ObfuscationType.X)` |
| `@PathVariable Long` / `@RequestParam Long` | `@DecryptId(ObfuscationType.X)` |
| 요청 DTO `*Id: Long` 필드 | `@field:EncryptId(ObfuscationType.X)` |
| Vocabulary 응답 함수 | `responseType NUMBER` → `responseType STRING`, example 인코딩 형식 |
| 테스트 URL 인자 | `id` → `id.encodedAs(ObfuscationType.X)` |

## 주의 / 후속 작업

- **`bingoMembers: List<Long>` (BingoBoardMembersPeriodUpdate Request / Response)** 는 적용 보류. List 의 각 요소를 `@EncryptId` 로 인코딩하려면 Jackson 의 `@JsonSerialize(contentUsing = ...)` 패턴이 별도로 필요. 후속 작업.
- **JWT memberId claim** 은 그대로 평문 Long. 클라이언트가 JWT 디코드 가능한 채널이라 obfuscation 의미가 약함. 별건으로 검토.
- BingoBoardUpdateApiTest 의 헬퍼 `checkUpdateResponse` 파라미터 `bingoBoardId: Long` → `String` 으로 변경 (URL 인자 타입 통일).

## 검증

각 도메인 커밋마다 `./gradlew test` 전체 통과. 최종 빌드 SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)