### PR TITLE
feat: List<Long> obfuscation 지원 (bingoMembers)

### DIFF
--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/request/BingoBoardMembersPeriodUpdateRequest.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/request/BingoBoardMembersPeriodUpdateRequest.kt
@@ -1,12 +1,15 @@
 package com.beside.groubing.domain.bingo.payload.request
 
 import com.beside.groubing.domain.bingo.payload.command.BingoBoardMembersPeriodUpdateCommand
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.id.EncryptId
 import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.NotEmpty
 import java.time.LocalDate
 
 class BingoBoardMembersPeriodUpdateRequest(
     @field:NotEmpty
+    @field:EncryptId(ObfuscationType.MEMBER)
     val bingoMembers: List<Long>,
 
     val since: LocalDate,

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMembersPeriodUpdateResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMembersPeriodUpdateResponse.kt
@@ -8,6 +8,7 @@ import java.time.LocalDate
 class BingoBoardMembersPeriodUpdateResponse private constructor(
     @EncryptId(ObfuscationType.BINGO_BOARD)
     val id: Long,
+    @EncryptId(ObfuscationType.MEMBER)
     val bingoMembers: List<Long>,
     val since: LocalDate?,
     val until: LocalDate?

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/EncryptIdAnnotationIntrospector.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/EncryptIdAnnotationIntrospector.kt
@@ -8,6 +8,11 @@ import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector
  * Jackson 이 직렬화·역직렬화 대상 필드의 [EncryptId] 어노테이션을 인식해
  * 그에 맞는 [EncryptIdSerializer] / [EncryptIdDeserializer] 를 사용하도록 연결한다.
  *
+ * - 단일 `Long` 필드는 [findSerializer] / [findDeserializer] 로 처리.
+ * - `List<Long>` / `Collection<Long>` 등 컨테이너 필드는 [findContentSerializer] / [findContentDeserializer]
+ *   로 처리해 각 요소(Long)에 같은 obfuscation 을 적용한다. Jackson 은 컨테이너 자체에 대해서는
+ *   기본 직렬화기를 쓰고, 요소 처리에만 우리가 반환한 (de)serializer 를 적용한다.
+ *
  * [ObfuscatedIdJacksonConfig] 에서 [com.fasterxml.jackson.databind.ObjectMapper] 에 등록한다.
  */
 class EncryptIdAnnotationIntrospector(
@@ -16,11 +21,29 @@ class EncryptIdAnnotationIntrospector(
 
     override fun findSerializer(a: Annotated): Any? {
         val annotation = a.getAnnotation(EncryptId::class.java) ?: return null
+        // 컨테이너 필드(List<Long> 등)는 findContentSerializer 가 맡고, 여기서는 단일 Long 만 처리한다.
+        if (a.isContainerField()) return null
         return EncryptIdSerializer(idObfuscator, annotation.value)
     }
 
     override fun findDeserializer(a: Annotated): Any? {
         val annotation = a.getAnnotation(EncryptId::class.java) ?: return null
+        if (a.isContainerField()) return null
         return EncryptIdDeserializer(idObfuscator, annotation.value)
     }
+
+    override fun findContentSerializer(a: Annotated): Any? {
+        val annotation = a.getAnnotation(EncryptId::class.java) ?: return null
+        return EncryptIdSerializer(idObfuscator, annotation.value)
+    }
+
+    override fun findContentDeserializer(a: Annotated): Any? {
+        val annotation = a.getAnnotation(EncryptId::class.java) ?: return null
+        return EncryptIdDeserializer(idObfuscator, annotation.value)
+    }
+
+    private fun Annotated.isContainerField(): Boolean =
+        Collection::class.java.isAssignableFrom(rawType) ||
+            Map::class.java.isAssignableFrom(rawType) ||
+            rawType.isArray
 }

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApiTest.kt
@@ -169,7 +169,9 @@ class BingoBoardUpdateApiTest(
                 ApiResponse.OK(BingoBoardMembersPeriodUpdateResponse.fromBingoBoard(aEmptyBingo)),
                 "update-bingo-members-period",
                 requestBody(
-                    "bingoMembers" requestType ARRAY means "빙고 참여 멤버 리스트" example "2, 3, 7",
+                    "bingoMembers" requestType ARRAY means
+                        "빙고 참여 멤버 ID 리스트 (각 요소는 obfuscated 문자열)" example
+                        "[\"MEbN4aLpqRzK\", \"k9aQ2nWxRzVp\"]",
                     "since" requestType DATE means "빙고 시작 일자" example "2023-05-08",
                     "until" requestType DATE means "빙고 종료 일자" example "2023-05-15"
                 ),

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/EncryptIdContentSerializationTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/EncryptIdContentSerializationTest.kt
@@ -1,0 +1,73 @@
+package com.beside.groubing.global.id
+
+import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.global.support.id.HashidsIdObfuscator
+import com.fasterxml.jackson.databind.AnnotationIntrospector
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * `@EncryptId` 가 컨테이너(List<Long>) 필드에 부착됐을 때
+ * [EncryptIdAnnotationIntrospector.findContentSerializer] / `findContentDeserializer`
+ * 가 각 요소(Long)를 obfuscate 하는지 검증한다.
+ *
+ * 다른 단위 테스트들이 mock 기반인 반면, 이 테스트는 실제 [ObjectMapper] 에 introspector 를 등록해
+ * 직렬화 / 역직렬화 round-trip 까지 확인한다.
+ */
+class EncryptIdContentSerializationTest : BehaviorSpec({
+
+    val idObfuscator: IdObfuscator = HashidsIdObfuscator(baseSalt = "test-salt", minLength = 12)
+
+    val mapper: ObjectMapper = jacksonObjectMapper().apply {
+        val introspector = EncryptIdAnnotationIntrospector(idObfuscator)
+        val existing = serializationConfig.annotationIntrospector
+        setAnnotationIntrospector(AnnotationIntrospector.pair(introspector, existing))
+    }
+
+    Given("List<Long> 필드에 @EncryptId(MEMBER) 가 부착된 DTO") {
+        val original = ContainerDto(memberIds = listOf(1L, 2L, 3L))
+        val expectedEncoded = original.memberIds.map { idObfuscator.encode(ObfuscationType.MEMBER, it) }
+
+        When("직렬화하면") {
+            val json = mapper.writeValueAsString(original)
+
+            Then("각 요소가 인코딩된 문자열 배열로 출력된다") {
+                expectedEncoded.forEach { json shouldContain "\"$it\"" }
+                // 숫자 그대로 나오면 안 됨
+                json shouldContain "\"memberIds\":["
+            }
+
+            Then("역직렬화하면 원본 Long 리스트로 복원된다") {
+                val restored = mapper.readValue(json, ContainerDto::class.java)
+                restored.memberIds shouldContainExactly original.memberIds
+            }
+        }
+    }
+
+    Given("빈 리스트") {
+        val original = ContainerDto(memberIds = emptyList())
+
+        When("직렬화·역직렬화 round-trip 하면") {
+            val json = mapper.writeValueAsString(original)
+            val restored = mapper.readValue(json, ContainerDto::class.java)
+
+            Then("빈 리스트가 그대로 유지된다") {
+                restored.memberIds shouldBe emptyList()
+            }
+        }
+    }
+}) {
+    /**
+     * 테스트 전용 DTO — `List<Long>` 필드 + `@field:EncryptId` 부착.
+     * 실제 응답·요청 DTO 와 동일한 어노테이션 패턴.
+     */
+    data class ContainerDto(
+        @field:EncryptId(ObfuscationType.MEMBER)
+        val memberIds: List<Long>
+    )
+}

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/EncryptIdContentSerializationTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/EncryptIdContentSerializationTest.kt
@@ -1,13 +1,17 @@
 package com.beside.groubing.global.id
 
 import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.global.domain.id.exception.InvalidObfuscatedIdException
 import com.beside.groubing.global.domain.id.port.IdObfuscator
 import com.beside.groubing.global.support.id.HashidsIdObfuscator
 import com.fasterxml.jackson.databind.AnnotationIntrospector
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 
@@ -61,6 +65,45 @@ class EncryptIdContentSerializationTest : BehaviorSpec({
             }
         }
     }
+
+    Given("List 의 일부 요소가 잘못된 인코딩 문자열") {
+        val validEncoded = idObfuscator.encode(ObfuscationType.MEMBER, 1L)
+        val invalidJson = """{"memberIds":["$validEncoded","!@#invalid"]}"""
+
+        When("역직렬화하면") {
+            Then("InvalidObfuscatedIdException 이 발생한다") {
+                // Jackson 은 Kotlin data class 생성자 호출 단계에서 던진 예외를
+                // ValueInstantiationException 으로 감싸므로 원인 체인을 따라 확인한다.
+                val thrown = shouldThrow<JsonMappingException> {
+                    mapper.readValue(invalidJson, ContainerDto::class.java)
+                }
+                // Jackson 이 ValueInstantiation/JsonMapping 으로 감싸 던지므로 원인 체인에서 확인.
+                val hasInvalidIdInChain = generateSequence(thrown as Throwable?) { it.cause }
+                    .any { it is InvalidObfuscatedIdException }
+                hasInvalidIdInChain shouldBe true
+            }
+        }
+    }
+
+    Given("Set<Long> 필드에 @EncryptId(BINGO_BOARD) 가 부착된 DTO") {
+        val original = SetContainerDto(bingoBoardIds = setOf(10L, 20L, 30L))
+
+        When("직렬화·역직렬화 round-trip 하면") {
+            val json = mapper.writeValueAsString(original)
+            val restored = mapper.readValue(json, SetContainerDto::class.java)
+
+            Then("각 요소가 BINGO_BOARD type 으로 인코딩되어 출력된다") {
+                original.bingoBoardIds.forEach { id ->
+                    val encoded = idObfuscator.encode(ObfuscationType.BINGO_BOARD, id)
+                    json shouldContain "\"$encoded\""
+                }
+            }
+
+            Then("Set 의 원본 요소들로 복원된다 (순서 무관)") {
+                restored.bingoBoardIds shouldContainExactlyInAnyOrder original.bingoBoardIds
+            }
+        }
+    }
 }) {
     /**
      * 테스트 전용 DTO — `List<Long>` 필드 + `@field:EncryptId` 부착.
@@ -69,5 +112,13 @@ class EncryptIdContentSerializationTest : BehaviorSpec({
     data class ContainerDto(
         @field:EncryptId(ObfuscationType.MEMBER)
         val memberIds: List<Long>
+    )
+
+    /**
+     * Set 컨테이너 검증용 DTO — List 외 Collection 구현에도 introspector 가 적용되는지 확인.
+     */
+    data class SetContainerDto(
+        @field:EncryptId(ObfuscationType.BINGO_BOARD)
+        val bingoBoardIds: Set<Long>
     )
 }

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/BingoVocabulary.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/BingoVocabulary.kt
@@ -76,7 +76,9 @@ fun bingoColorValue(fieldName: String = "bingoColorValue") =
         "Blue : `#8BC0FC`, Orange: `#FCB179`, Red: `FF8282`, Green: `#55DEB5`, Purple : `#B8B7FC`"
 
 fun bingoMembers(fieldName: String = "bingoMembers") =
-    fieldName responseType ARRAY means "빙고 참여 멤버 ID 리스트" example "[2, 3, 7]"
+    fieldName responseType ARRAY means
+        "빙고 참여 멤버 ID 리스트 (각 요소는 obfuscated 문자열)" example
+        "[\"MEbN4aLpqRzK\", \"k9aQ2nWxRzVp\"]"
 
 // --- Bingo Lines / Items ---
 


### PR DESCRIPTION
## 개요

Phase 2 PR(#17)에서 보류했던 `bingoMembers: List<Long>` 의 obfuscation 을 풀어낸다.

`@EncryptId` 가 컨테이너 필드(`List<Long>` / 배열 등)에 부착됐을 때 각 요소(Long)에 obfuscation 이 적용되도록 [`EncryptIdAnnotationIntrospector`] 를 보강했다.

base: `refactor/explicit-path-variable-names` (#18). 그 PR 머지 후 base 를 dev 로 변경 또는 stacked 머지.

## 변경

### 인프라
- `EncryptIdAnnotationIntrospector`:
  - **추가**: `findContentSerializer` / `findContentDeserializer` — 컨테이너 요소(Long)용 (de)serializer 반환.
  - **보강**: `findSerializer` / `findDeserializer` 가 컨테이너 타입이면 null 반환 (이게 빠지면 List 자체를 Long 으로 직렬화하려다 ClassCastException).

### 적용
- `BingoBoardMembersPeriodUpdateRequest.bingoMembers` 에 `@field:EncryptId(MEMBER)`.
- `BingoBoardMembersPeriodUpdateResponse.bingoMembers` 에 `@EncryptId(MEMBER)`.
- `BingoVocabulary.bingoMembers` / `BingoBoardUpdateApiTest` 의 RestDocs example 을 인코딩 표기로 갱신.

### 테스트
- `EncryptIdContentSerializationTest` 신규: 실제 `ObjectMapper` 에 introspector 등록 → `List<Long>` round-trip 검증, 빈 리스트 케이스.

## 검증

`./gradlew test` 전체 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)