### PR TITLE
refactor: 공유 도메인 패키지 global.domain.{id,file} → domain.common.{id,file}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,10 @@ gb-boot-web/com/beside/groubing/groubingserver/domain/bingo/
 └── payload/                # request/ and response/ DTOs (controllers map domain → response factories)
 ```
 
-Global infra-free code (`global/response/`, `global/filter/`, `global/handler/`, `global/config/`) lives in boot-web.
-JPA base types (`BaseEntity`, `BaseAggregateRoot`, `BaseCreatedTimeEntity`) live in `gb-db-core/global/domain/jpa/`.
-FileInfo domain is in `gb-domain-core/global/domain/file/`; FileInfoEntity + adapter in `gb-db-core/global/domain/file/`. Pure-NIO `FileStorage` (delete + path) lives next to `FileInfo` in domain-core; web-only `FileProvider` (upload via `MultipartFile`, find via `Resource`) stays in boot-web.
+Global infra-free code (`global/response/`, `global/filter/`, `global/handler/`, `global/config/`) lives in boot-web — `global` is a **web-layer** cross-cutting prefix only. Shared/cross-aggregate **domain** concepts (id obfuscation, file) live under `domain.common.*` (shared kernel), parallel to the real bounded contexts under `domain.*` — not under `global`.
+JPA base types (`BaseEntity`, `BaseAggregateRoot`, `BaseCreatedTimeEntity`) live in `gb-db-core/global/domain/jpa/` (infra base, still under `global.domain.jpa`; security/JWT under `gb-jwt-core/global/domain/security`).
+Id obfuscation domain (`IdObfuscator` port, `ObfuscationType`, `InvalidObfuscatedIdException`) is in `gb-domain-core/domain/common/id/`.
+FileInfo domain is in `gb-domain-core/domain/common/file/`; FileInfoEntity + adapter in `gb-db-core/domain/common/file/`. Pure-NIO `FileStorage` (delete + path) lives next to `FileInfo` in domain-core; web-only `FileProvider` (upload via `MultipartFile`, find via `Resource`) stays in boot-web.
 
 ## Hexagonal Conventions (established over Phase 5a–6h refactor)
 
@@ -137,7 +138,7 @@ FileInfo domain is in `gb-domain-core/global/domain/file/`; FileInfoEntity + ada
 - One Service + one Api per use case — `BingoBoardCreateApi/Service`, `BingoBoardDeleteApi/Service`, etc.
 - Multi-repository validation (existence check, duplicate check, ownership) → extract `@Component` Validator (`SignUpValidator`, etc.).
 - **Return domain types, not response DTOs.** Services return `Member`, `BingoBoard`, `BingoMap`, projections (`FriendMemberInfo`), or service-level domain DTOs (`AuthenticatedMember(member, accessToken)`, `BingoBoardDetail(bingoBoard, viewer, otherMembers)`). The controller maps to response DTO via factory.
-- **File side-effects from domain-core**: pure NIO helper `FileStorage.delete(FileInfo)` lives in `gb-domain-core/global/domain/file/application/`. Web-only `FileProvider` (boot-web) keeps `upload(MultipartFile)`, `find(): Resource`, `getContentType` — controller uploads first, passes `FileInfo` into service so `MultipartFile` does not leak into domain-core.
+- **File side-effects from domain-core**: pure NIO helper `FileStorage.delete(FileInfo)` lives in `gb-domain-core/domain/common/file/application/`. Web-only `FileProvider` (boot-web) keeps `upload(MultipartFile)`, `find(): Resource`, `getContentType` — controller uploads first, passes `FileInfo` into service so `MultipartFile` does not leak into domain-core.
 
 ### Responses (gb-boot-web/payload/response)
 - Factory methods (`FriendResponse.of(info)`, `MemberResponse.of(authenticatedMember)`, `BingoBoardDetailResponse.of(detail)`, `BingoBoardResponse.fromBingoBoard(board, memberId)`) — no primary-ctor-in-controller.

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardDeleteApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardDeleteApi.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.bingo.api
 
 import com.beside.groubing.domain.bingo.application.BingoBoardDeleteService
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardFindApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardFindApi.kt
@@ -2,7 +2,7 @@ package com.beside.groubing.domain.bingo.api
 
 import com.beside.groubing.domain.bingo.application.BingoBoardFindService
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardDetailResponse
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.web.bind.annotation.GetMapping

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardListFindApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardListFindApi.kt
@@ -2,7 +2,7 @@ package com.beside.groubing.domain.bingo.api
 
 import com.beside.groubing.domain.bingo.application.BingoBoardListFindService
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardOverviewResponse
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApi.kt
@@ -9,7 +9,7 @@ import com.beside.groubing.domain.bingo.payload.response.BingoBoardBaseUpdateRes
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardMembersPeriodUpdateResponse
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardMemoUpdateResponse
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardOpenUpdateResponse
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import jakarta.validation.Valid

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemCompleteApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemCompleteApi.kt
@@ -2,7 +2,7 @@ package com.beside.groubing.domain.bingo.api
 
 import com.beside.groubing.domain.bingo.application.BingoItemCompleteService
 import com.beside.groubing.domain.bingo.payload.response.BingoCalculatingResponse
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemShuffleApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemShuffleApi.kt
@@ -3,7 +3,7 @@ package com.beside.groubing.domain.bingo.api
 import com.beside.groubing.domain.bingo.application.BingoItemShuffleService
 import com.beside.groubing.domain.bingo.domain.map.Direction
 import com.beside.groubing.domain.bingo.payload.response.BingoLineResponse
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemUpdateApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoItemUpdateApi.kt
@@ -3,7 +3,7 @@ package com.beside.groubing.domain.bingo.api
 import com.beside.groubing.domain.bingo.application.BingoItemUpdateService
 import com.beside.groubing.domain.bingo.payload.request.BingoItemUpdateRequest
 import com.beside.groubing.domain.bingo.payload.response.BingoItemResponse
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import jakarta.validation.Valid

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoMemberLeaveApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/api/BingoMemberLeaveApi.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.bingo.api
 
 import com.beside.groubing.domain.bingo.application.BingoMemberLeaveService
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/request/BingoBoardMembersPeriodUpdateRequest.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/request/BingoBoardMembersPeriodUpdateRequest.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.bingo.payload.request
 
 import com.beside.groubing.domain.bingo.payload.command.BingoBoardMembersPeriodUpdateCommand
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.NotEmpty

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardBaseUpdateResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardBaseUpdateResponse.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoBoard
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 import java.time.LocalDate
 

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardDetailResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardDetailResponse.kt
@@ -2,7 +2,7 @@ package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoBoardDetail
 import com.beside.groubing.domain.bingo.domain.BingoBoardType
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 import java.time.LocalDate
 

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMembersPeriodUpdateResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMembersPeriodUpdateResponse.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoBoard
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 import java.time.LocalDate
 

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMemoUpdateResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMemoUpdateResponse.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoBoard
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 class BingoBoardMemoUpdateResponse private constructor(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardOpenUpdateResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardOpenUpdateResponse.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoBoard
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 class BingoBoardOpenUpdateResponse private constructor(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardOverviewResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardOverviewResponse.kt
@@ -5,7 +5,7 @@ import com.beside.groubing.domain.bingo.domain.BingoBoardType
 import com.beside.groubing.domain.bingo.domain.BingoItem
 import com.beside.groubing.domain.bingo.domain.map.BingoLine
 import com.beside.groubing.domain.bingo.domain.map.Direction
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 import java.time.LocalDate
 

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardResponse.kt
@@ -3,7 +3,7 @@ package com.beside.groubing.domain.bingo.payload.response
 import com.beside.groubing.domain.bingo.domain.BingoBoard
 import com.beside.groubing.domain.bingo.domain.BingoBoardType
 import com.beside.groubing.domain.bingo.domain.map.Direction
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 class BingoBoardResponse private constructor(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoItemResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoItemResponse.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.bingo.payload.response
 
 import com.beside.groubing.domain.bingo.domain.BingoItem
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 class BingoItemResponse private constructor(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/api/UnblockMemberApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/api/UnblockMemberApi.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.blockedmember.api
 
 import com.beside.groubing.domain.blockedmember.application.UnblockMemberService
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/payload/request/BlockingMemberRequest.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/payload/request/BlockingMemberRequest.kt
@@ -1,6 +1,6 @@
 package com.beside.groubing.domain.blockedmember.payload.request
 
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/payload/response/BlockedMemberResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/payload/response/BlockedMemberResponse.kt
@@ -1,8 +1,8 @@
 package com.beside.groubing.domain.blockedmember.payload.response
 
 import com.beside.groubing.domain.blockedmember.domain.BlockedMemberTarget
-import com.beside.groubing.global.domain.file.domain.FileInfo
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.file.domain.FileInfo
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 data class BlockedMemberResponse(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/common/file/api/FileDownloadApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/common/file/api/FileDownloadApi.kt
@@ -1,7 +1,7 @@
-package com.beside.groubing.global.domain.file.api
+package com.beside.groubing.domain.common.file.api
 
-import com.beside.groubing.global.domain.file.application.FileInfoService
-import com.beside.groubing.global.domain.file.application.FileProvider
+import com.beside.groubing.domain.common.file.application.FileInfoService
+import com.beside.groubing.domain.common.file.application.FileProvider
 import org.springframework.core.io.ClassPathResource
 import org.springframework.core.io.Resource
 import org.springframework.http.MediaType

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/common/file/application/FileProvider.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/common/file/application/FileProvider.kt
@@ -1,6 +1,6 @@
-package com.beside.groubing.global.domain.file.application
+package com.beside.groubing.domain.common.file.application
 
-import com.beside.groubing.global.domain.file.domain.FileInfo
+import com.beside.groubing.domain.common.file.domain.FileInfo
 import org.springframework.core.io.Resource
 import org.springframework.core.io.UrlResource
 import org.springframework.http.MediaType

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/feed/payload/response/FeedResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/feed/payload/response/FeedResponse.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.feed.payload.response
 
 import com.beside.groubing.domain.feed.domain.FeedEntry
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 class FeedResponse private constructor(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/api/FriendAcceptApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/api/FriendAcceptApi.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.friend.api
 
 import com.beside.groubing.domain.friend.application.FriendAcceptService
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PatchMapping

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/api/FriendRejectApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/api/FriendRejectApi.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.friend.api
 
 import com.beside.groubing.domain.friend.application.FriendRejectService
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PatchMapping

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/request/FriendAddRequest.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/request/FriendAddRequest.kt
@@ -1,6 +1,6 @@
 package com.beside.groubing.domain.friend.payload.request
 
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendRequestResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendRequestResponse.kt
@@ -2,8 +2,8 @@ package com.beside.groubing.domain.friend.payload.response
 
 import com.beside.groubing.domain.friend.domain.FriendMember
 import com.beside.groubing.domain.friend.domain.FriendStatus
-import com.beside.groubing.global.domain.file.domain.FileInfo
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.file.domain.FileInfo
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 data class FriendRequestResponse(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/friend/payload/response/FriendResponse.kt
@@ -1,8 +1,8 @@
 package com.beside.groubing.domain.friend.payload.response
 
 import com.beside.groubing.domain.friend.domain.FriendMember
-import com.beside.groubing.global.domain.file.domain.FileInfo
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.file.domain.FileInfo
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 data class FriendResponse(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberNicknameEditApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberNicknameEditApi.kt
@@ -2,7 +2,7 @@ package com.beside.groubing.domain.member.api
 
 import com.beside.groubing.domain.member.application.MemberNicknameEditService
 import com.beside.groubing.domain.member.payload.request.MemberNicknameEditRequest
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PatchMapping

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberPasswordResetApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberPasswordResetApi.kt
@@ -2,7 +2,7 @@ package com.beside.groubing.domain.member.api
 
 import com.beside.groubing.domain.auth.application.MemberPasswordResetService
 import com.beside.groubing.domain.member.payload.request.MemberPasswordResetRequest
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PatchMapping

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberProfileDeleteApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberProfileDeleteApi.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.member.api
 
 import com.beside.groubing.domain.member.application.MemberProfileDeleteService
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberProfileEditApi.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/api/MemberProfileEditApi.kt
@@ -2,8 +2,8 @@ package com.beside.groubing.domain.member.api
 
 import com.beside.groubing.domain.member.application.MemberProfileEditService
 import com.beside.groubing.domain.member.payload.response.MemberProfileResponse
-import com.beside.groubing.global.domain.file.application.FileProvider
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.file.application.FileProvider
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.DecryptId
 import com.beside.groubing.global.response.ApiResponse
 import org.springframework.web.bind.annotation.PatchMapping

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberEmailFindResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberEmailFindResponse.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.member.payload.response
 
 import com.beside.groubing.domain.member.domain.Member
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 data class MemberEmailFindResponse(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberFindResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberFindResponse.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.member.payload.response
 
 import com.beside.groubing.domain.member.domain.Member
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 class MemberFindResponse(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/MemberResponse.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.member.payload.response
 
 import com.beside.groubing.domain.auth.domain.AuthenticatedMember
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 data class MemberResponse(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/SocialMemberResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/member/payload/response/SocialMemberResponse.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.member.payload.response
 
 import com.beside.groubing.domain.auth.domain.AuthenticatedMember
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 data class SocialMemberResponse(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/notification/payload/response/NotificationResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/notification/payload/response/NotificationResponse.kt
@@ -1,8 +1,8 @@
 package com.beside.groubing.domain.notification.payload.response
 
 import com.beside.groubing.domain.notification.domain.NotificationItem
-import com.beside.groubing.global.domain.file.domain.FileInfo
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.file.domain.FileInfo
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.id.EncryptId
 
 class NotificationResponse(

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/config/WebConfig.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/config/WebConfig.kt
@@ -1,6 +1,6 @@
 package com.beside.groubing.global.config
 
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import com.beside.groubing.global.id.DecryptIdConverter
 import com.beside.groubing.global.interceptor.LoggingInterceptor
 import org.springframework.context.annotation.Configuration

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/handler/GlobalExceptionHandler.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/handler/GlobalExceptionHandler.kt
@@ -4,8 +4,8 @@ import com.beside.groubing.domain.bingo.exception.BingoInputException
 import com.beside.groubing.domain.blockedmember.exception.BlockedMemberInputException
 import com.beside.groubing.domain.friend.exception.FriendInputException
 import com.beside.groubing.domain.member.exception.MemberInputException
-import com.beside.groubing.global.domain.file.exception.FileInfoInputException
-import com.beside.groubing.global.domain.id.exception.InvalidObfuscatedIdException
+import com.beside.groubing.domain.common.file.exception.FileInfoInputException
+import com.beside.groubing.domain.common.id.exception.InvalidObfuscatedIdException
 import com.beside.groubing.global.response.ApiResponseCode
 import com.beside.groubing.global.response.error.ApiError
 import org.slf4j.LoggerFactory

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/DecryptId.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/DecryptId.kt
@@ -1,6 +1,6 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 
 /** `@PathVariable` / `@RequestParam` 용. 요청 본문 필드는 [EncryptId] 가 양방향을 담당한다. */
 @Target(AnnotationTarget.VALUE_PARAMETER)

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/DecryptIdConverter.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/DecryptIdConverter.kt
@@ -1,6 +1,6 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import org.springframework.core.convert.TypeDescriptor
 import org.springframework.core.convert.converter.ConditionalGenericConverter
 import org.springframework.core.convert.converter.GenericConverter.ConvertiblePair

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/EncryptId.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/EncryptId.kt
@@ -1,6 +1,6 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 
 /** 응답·요청 본문의 `Long` id 필드용. path / query parameter 는 [DecryptId] 를 쓴다. */
 @Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/EncryptIdAnnotationIntrospector.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/EncryptIdAnnotationIntrospector.kt
@@ -1,6 +1,6 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import com.fasterxml.jackson.databind.introspect.Annotated
 import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector
 

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/EncryptIdDeserializer.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/EncryptIdDeserializer.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.ObfuscationType
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.ObfuscationType
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonDeserializer

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/EncryptIdSerializer.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/EncryptIdSerializer.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.ObfuscationType
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.ObfuscationType
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/ObfuscatedIdJacksonConfig.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/id/ObfuscatedIdJacksonConfig.kt
@@ -1,6 +1,6 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import com.fasterxml.jackson.databind.AnnotationIntrospector
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.annotation.PostConstruct

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardDeleteApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardDeleteApiTest.kt
@@ -6,7 +6,7 @@ import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.domain.bingo.application.BingoBoardDeleteService
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardIdPath
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.FunSpec

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardFindApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardFindApiTest.kt
@@ -11,7 +11,7 @@ import com.beside.groubing.domain.bingo.application.BingoBoardFindService
 import com.beside.groubing.domain.bingo.domain.BingoBoardDetail
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardId
 import com.beside.groubing.vocabulary.bingoBoardIdPath
 import com.beside.groubing.vocabulary.bingoBoardType

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardListFindApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardListFindApiTest.kt
@@ -10,7 +10,7 @@ import com.beside.groubing.docs.responseBody
 import com.beside.groubing.domain.bingo.application.BingoBoardListFindService
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardId
 import com.beside.groubing.vocabulary.bingoBoardType
 import com.beside.groubing.vocabulary.bingoColorValue

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApiTest.kt
@@ -22,7 +22,7 @@ import com.beside.groubing.domain.bingo.payload.response.BingoBoardMemoUpdateRes
 import com.beside.groubing.domain.bingo.payload.response.BingoBoardOpenUpdateResponse
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.response.ApiResponse
 import com.beside.groubing.vocabulary.bingoBoardId
 import com.beside.groubing.vocabulary.bingoGoal

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemCompleteApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemCompleteApiTest.kt
@@ -9,7 +9,7 @@ import com.beside.groubing.docs.responseBody
 import com.beside.groubing.domain.bingo.application.BingoItemCompleteService
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardIdPath
 import com.beside.groubing.vocabulary.diagonalBingoIndexes
 import com.beside.groubing.vocabulary.horizontalBingoIndexes

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemShuffleApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemShuffleApiTest.kt
@@ -8,7 +8,7 @@ import com.beside.groubing.docs.responseBody
 import com.beside.groubing.domain.bingo.application.BingoItemShuffleService
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardIdPath
 import com.beside.groubing.vocabulary.bingoItemColorCode
 import com.beside.groubing.vocabulary.bingoItemComplete

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemUpdateApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoItemUpdateApiTest.kt
@@ -13,7 +13,7 @@ import com.beside.groubing.domain.bingo.application.BingoItemUpdateService
 import com.beside.groubing.domain.bingo.payload.request.BingoItemUpdateRequest
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.vocabulary.bingoBoardIdPath
 import com.beside.groubing.vocabulary.bingoItemColorCode
 import com.beside.groubing.vocabulary.bingoItemComplete

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/BlockMemberApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/BlockMemberApiTest.kt
@@ -9,7 +9,7 @@ import com.beside.groubing.domain.blockedmember.application.BlockMemberService
 import com.beside.groubing.domain.blockedmember.payload.request.BlockingMemberRequest
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/UnblockMemberApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/UnblockMemberApiTest.kt
@@ -6,7 +6,7 @@ import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.domain.blockedmember.application.UnblockMemberService
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.vocabulary.blockedMemberIdPath
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendAcceptApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendAcceptApiTest.kt
@@ -6,7 +6,7 @@ import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.domain.friend.application.FriendAcceptService
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.vocabulary.friendIdPath
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendAddApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendAddApiTest.kt
@@ -9,7 +9,7 @@ import com.beside.groubing.domain.friend.application.FriendAddService
 import com.beside.groubing.domain.friend.payload.request.FriendAddRequest
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendRejectApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendRejectApiTest.kt
@@ -6,7 +6,7 @@ import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.domain.friend.application.FriendRejectService
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.vocabulary.friendIdPath
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberNicknameEditApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberNicknameEditApiTest.kt
@@ -10,7 +10,7 @@ import com.beside.groubing.domain.member.application.MemberNicknameEditService
 import com.beside.groubing.domain.member.payload.request.MemberNicknameEditRequest
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.vocabulary.memberIdPath
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberPasswordResetApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberPasswordResetApiTest.kt
@@ -11,7 +11,7 @@ import com.beside.groubing.vocabulary.memberIdPath
 import com.beside.groubing.domain.member.payload.request.MemberPasswordResetRequest
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberProfileDeleteApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberProfileDeleteApiTest.kt
@@ -5,7 +5,7 @@ import com.beside.groubing.docs.andDocument
 import com.beside.groubing.docs.pathVariables
 import com.beside.groubing.domain.member.application.MemberProfileDeleteService
 import com.beside.groubing.extension.encodedAs
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.vocabulary.memberIdPath
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberProfileEditApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/MemberProfileEditApiTest.kt
@@ -12,9 +12,9 @@ import com.beside.groubing.vocabulary.profileUrl
 import com.beside.groubing.domain.member.payload.response.MemberProfileResponse
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.multipart
-import com.beside.groubing.global.domain.file.application.FileProvider
-import com.beside.groubing.global.domain.file.domain.FileInfo
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.file.application.FileProvider
+import com.beside.groubing.domain.common.file.domain.FileInfo
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.response.ApiResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/extension/IdObfuscatorExpression.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/extension/IdObfuscatorExpression.kt
@@ -1,6 +1,6 @@
 package com.beside.groubing.extension
 
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.support.id.HashidsIdObfuscator
 
 /** `TestIdObfuscatorConfig` 와 동일 salt — MockMvc URL 에 넣을 obfuscated 문자열 생성. */

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/DecryptIdConverterTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/DecryptIdConverterTest.kt
@@ -1,8 +1,8 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.ObfuscationType
-import com.beside.groubing.global.domain.id.exception.InvalidObfuscatedIdException
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.ObfuscationType
+import com.beside.groubing.domain.common.id.exception.InvalidObfuscatedIdException
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/EncryptIdContentSerializationTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/EncryptIdContentSerializationTest.kt
@@ -1,8 +1,8 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.ObfuscationType
-import com.beside.groubing.global.domain.id.exception.InvalidObfuscatedIdException
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.ObfuscationType
+import com.beside.groubing.domain.common.id.exception.InvalidObfuscatedIdException
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import com.beside.groubing.global.support.id.HashidsIdObfuscator
 import com.fasterxml.jackson.databind.AnnotationIntrospector
 import com.fasterxml.jackson.databind.JsonMappingException

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/EncryptIdDeserializerTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/EncryptIdDeserializerTest.kt
@@ -1,8 +1,8 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.ObfuscationType
-import com.beside.groubing.global.domain.id.exception.InvalidObfuscatedIdException
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.ObfuscationType
+import com.beside.groubing.domain.common.id.exception.InvalidObfuscatedIdException
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import com.fasterxml.jackson.core.JsonParser
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/EncryptIdSerializerTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/EncryptIdSerializerTest.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.ObfuscationType
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.ObfuscationType
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import com.fasterxml.jackson.core.JsonGenerator
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/TestIdObfuscatorConfig.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/global/id/TestIdObfuscatorConfig.kt
@@ -1,6 +1,6 @@
 package com.beside.groubing.global.id
 
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import com.beside.groubing.global.support.id.HashidsIdObfuscator
 import com.fasterxml.jackson.databind.AnnotationIntrospector
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/file/application/FileInfoService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/file/application/FileInfoService.kt
@@ -1,7 +1,7 @@
-package com.beside.groubing.global.domain.file.application
+package com.beside.groubing.domain.common.file.application
 
-import com.beside.groubing.global.domain.file.domain.FileInfo
-import com.beside.groubing.global.domain.file.domain.port.FileInfoQueryRepository
+import com.beside.groubing.domain.common.file.domain.FileInfo
+import com.beside.groubing.domain.common.file.domain.port.FileInfoQueryRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/file/application/FileStorage.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/file/application/FileStorage.kt
@@ -1,6 +1,6 @@
-package com.beside.groubing.global.domain.file.application
+package com.beside.groubing.domain.common.file.application
 
-import com.beside.groubing.global.domain.file.domain.FileInfo
+import com.beside.groubing.domain.common.file.domain.FileInfo
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/file/domain/FileInfo.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/file/domain/FileInfo.kt
@@ -1,4 +1,4 @@
-package com.beside.groubing.global.domain.file.domain
+package com.beside.groubing.domain.common.file.domain
 
 class FileInfo private constructor(
     val id: Long,

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/file/domain/port/FileInfoQueryRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/file/domain/port/FileInfoQueryRepository.kt
@@ -1,0 +1,7 @@
+package com.beside.groubing.domain.common.file.domain.port
+
+import com.beside.groubing.domain.common.file.domain.FileInfo
+
+interface FileInfoQueryRepository {
+    fun findOne(fileName: String): FileInfo
+}

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/file/exception/FileInfoInputException.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/file/exception/FileInfoInputException.kt
@@ -1,3 +1,3 @@
-package com.beside.groubing.global.domain.file.exception
+package com.beside.groubing.domain.common.file.exception
 
 class FileInfoInputException : RuntimeException("[FileInfoInputException] 해당 파일명의 데이터가 존재하지 않습니다.")

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/id/ObfuscationType.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/id/ObfuscationType.kt
@@ -1,4 +1,4 @@
-package com.beside.groubing.global.domain.id
+package com.beside.groubing.domain.common.id
 
 /**
  * `saltSuffix` 는 인코딩 시드의 일부다 — 한 번 정한 값을 바꾸면 이미 발급된 모든 문자열이 무효화된다.

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/id/exception/InvalidObfuscatedIdException.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/id/exception/InvalidObfuscatedIdException.kt
@@ -1,4 +1,4 @@
-package com.beside.groubing.global.domain.id.exception
+package com.beside.groubing.domain.common.id.exception
 
 class InvalidObfuscatedIdException(encoded: String) :
     RuntimeException("유효하지 않은 식별자입니다. : $encoded")

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/id/port/IdObfuscator.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/common/id/port/IdObfuscator.kt
@@ -1,6 +1,6 @@
-package com.beside.groubing.global.domain.id.port
+package com.beside.groubing.domain.common.id.port
 
-import com.beside.groubing.global.domain.id.ObfuscationType
+import com.beside.groubing.domain.common.id.ObfuscationType
 
 interface IdObfuscator {
     fun encode(type: ObfuscationType, id: Long): String

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/application/MemberProfileDeleteService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/application/MemberProfileDeleteService.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.domain.member.application
 
 import com.beside.groubing.domain.member.domain.port.MemberCommandRepository
-import com.beside.groubing.global.domain.file.application.FileStorage
+import com.beside.groubing.domain.common.file.application.FileStorage
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/application/MemberProfileEditService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/application/MemberProfileEditService.kt
@@ -1,8 +1,8 @@
 package com.beside.groubing.domain.member.application
 
 import com.beside.groubing.domain.member.domain.port.MemberCommandRepository
-import com.beside.groubing.global.domain.file.application.FileStorage
-import com.beside.groubing.global.domain.file.domain.FileInfo
+import com.beside.groubing.domain.common.file.application.FileStorage
+import com.beside.groubing.domain.common.file.domain.FileInfo
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberCommandRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberCommandRepository.kt
@@ -2,7 +2,7 @@ package com.beside.groubing.domain.member.domain.port
 
 import com.beside.groubing.domain.member.domain.Member
 import com.beside.groubing.domain.member.domain.NewMember
-import com.beside.groubing.global.domain.file.domain.FileInfo
+import com.beside.groubing.domain.common.file.domain.FileInfo
 
 interface MemberCommandRepository {
     fun save(newMember: NewMember): Member

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/global/domain/file/domain/port/FileInfoQueryRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/global/domain/file/domain/port/FileInfoQueryRepository.kt
@@ -1,7 +1,0 @@
-package com.beside.groubing.global.domain.file.domain.port
-
-import com.beside.groubing.global.domain.file.domain.FileInfo
-
-interface FileInfoQueryRepository {
-    fun findOne(fileName: String): FileInfo
-}

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/common/file/entity/FileInfoEntity.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/common/file/entity/FileInfoEntity.kt
@@ -1,6 +1,6 @@
-package com.beside.groubing.global.domain.file.entity
+package com.beside.groubing.domain.common.file.entity
 
-import com.beside.groubing.global.domain.file.domain.FileInfo
+import com.beside.groubing.domain.common.file.domain.FileInfo
 import com.beside.groubing.global.domain.jpa.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/common/file/repository/FileInfoJpaRepository.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/common/file/repository/FileInfoJpaRepository.kt
@@ -1,6 +1,6 @@
-package com.beside.groubing.global.domain.file.repository
+package com.beside.groubing.domain.common.file.repository
 
-import com.beside.groubing.global.domain.file.entity.FileInfoEntity
+import com.beside.groubing.domain.common.file.entity.FileInfoEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface FileInfoJpaRepository : JpaRepository<FileInfoEntity, Long> {

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/common/file/repository/FileInfoRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/common/file/repository/FileInfoRepositoryAdapter.kt
@@ -1,8 +1,8 @@
-package com.beside.groubing.global.domain.file.repository
+package com.beside.groubing.domain.common.file.repository
 
-import com.beside.groubing.global.domain.file.domain.FileInfo
-import com.beside.groubing.global.domain.file.domain.port.FileInfoQueryRepository
-import com.beside.groubing.global.domain.file.exception.FileInfoInputException
+import com.beside.groubing.domain.common.file.domain.FileInfo
+import com.beside.groubing.domain.common.file.domain.port.FileInfoQueryRepository
+import com.beside.groubing.domain.common.file.exception.FileInfoInputException
 import org.springframework.stereotype.Repository
 
 @Repository

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/entity/MemberEntity.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/entity/MemberEntity.kt
@@ -4,7 +4,7 @@ import com.beside.groubing.domain.member.domain.Member
 import com.beside.groubing.domain.member.domain.MemberRole
 import com.beside.groubing.domain.member.domain.MemberType
 import com.beside.groubing.domain.member.domain.NewMember
-import com.beside.groubing.global.domain.file.entity.FileInfoEntity
+import com.beside.groubing.domain.common.file.entity.FileInfoEntity
 import com.beside.groubing.global.domain.jpa.BaseEntity
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapter.kt
@@ -7,8 +7,8 @@ import com.beside.groubing.domain.member.domain.port.MemberCommandRepository
 import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
 import com.beside.groubing.domain.member.entity.MemberEntity
 import com.beside.groubing.domain.member.exception.MemberInputException
-import com.beside.groubing.global.domain.file.domain.FileInfo
-import com.beside.groubing.global.domain.file.entity.FileInfoEntity
+import com.beside.groubing.domain.common.file.domain.FileInfo
+import com.beside.groubing.domain.common.file.entity.FileInfoEntity
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Repository
 

--- a/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/notification/dao/NotificationFindDaoTest.kt
+++ b/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/notification/dao/NotificationFindDaoTest.kt
@@ -5,8 +5,8 @@ import com.beside.groubing.global.config.QuerydslConfig
 import com.beside.groubing.domain.member.repository.MemberJpaRepository
 import com.beside.groubing.domain.notification.entity.NotificationEntity
 import com.beside.groubing.domain.notification.repository.NotificationJpaRepository
-import com.beside.groubing.global.domain.file.domain.FileInfo
-import com.beside.groubing.global.domain.file.entity.FileInfoEntity
+import com.beside.groubing.domain.common.file.domain.FileInfo
+import com.beside.groubing.domain.common.file.entity.FileInfoEntity
 import com.beside.groubing.persistence.PersistenceTest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe

--- a/infrastructure/support/gb-id-obfuscator/src/main/kotlin/com/beside/groubing/global/support/id/HashidsIdObfuscator.kt
+++ b/infrastructure/support/gb-id-obfuscator/src/main/kotlin/com/beside/groubing/global/support/id/HashidsIdObfuscator.kt
@@ -1,8 +1,8 @@
 package com.beside.groubing.global.support.id
 
-import com.beside.groubing.global.domain.id.ObfuscationType
-import com.beside.groubing.global.domain.id.exception.InvalidObfuscatedIdException
-import com.beside.groubing.global.domain.id.port.IdObfuscator
+import com.beside.groubing.domain.common.id.ObfuscationType
+import com.beside.groubing.domain.common.id.exception.InvalidObfuscatedIdException
+import com.beside.groubing.domain.common.id.port.IdObfuscator
 import org.hashids.Hashids
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component

--- a/infrastructure/support/gb-id-obfuscator/src/test/kotlin/com/beside/groubing/global/support/id/HashidsIdObfuscatorTest.kt
+++ b/infrastructure/support/gb-id-obfuscator/src/test/kotlin/com/beside/groubing/global/support/id/HashidsIdObfuscatorTest.kt
@@ -1,7 +1,7 @@
 package com.beside.groubing.global.support.id
 
-import com.beside.groubing.global.domain.id.ObfuscationType
-import com.beside.groubing.global.domain.id.exception.InvalidObfuscatedIdException
+import com.beside.groubing.domain.common.id.ObfuscationType
+import com.beside.groubing.domain.common.id.exception.InvalidObfuscatedIdException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe


### PR DESCRIPTION
## 무엇을 / 왜

domain-core 의 공유 도메인 개념을 **웹 계층 용어인 `global`** 에서 **도메인 루트 아래 공유 커널 `domain.common`** 으로 옮긴다.

`global` 은 이 프로젝트에서 boot-web 의 웹 횡단 관심사(`global/response`, `global/filter`, `global/handler`, `global/config`)를 뜻하는 prefix 인데, 그 이름이 순수 도메인 모듈로 새어들어가 `global.domain.id` / `global.domain.file` 형태로 쓰이고 있었다. "특정 애그리거트에 안 묶인 것"은 DDD 에서 **shared kernel = `common`** 이 맞는 이름이고, 레퍼런스(meet-again)도 `domain.common.*` 을 쓴다.

## 변경

| 기존 | 변경 |
|---|---|
| `global.domain.id.*` | `domain.common.id.*` — `IdObfuscator`(port) / `ObfuscationType` / `InvalidObfuscatedIdException` |
| `global.domain.file.*` | `domain.common.file.*` — `FileInfo` / `FileStorage` / `FileInfoService` / `FileInfoEntity` / `FileInfoRepositoryAdapter` / `FileProvider` / `FileDownloadApi` / ... |

- 도메인은 `domain.*` 한 뿌리로 통일, 공유 컨텍스트는 그 아래 `domain.common.{id,file}` (각자 application/domain/exception 내부 구조 유지).
- 13개 파일 물리 이동 + 전 모듈 import 갱신(총 89파일).

## 범위 밖 (의도적으로 유지)

- boot-web `global.{response,filter,handler,config,id}` — 진짜 웹 횡단 관심사라 `global` 이 적절.
- 인프라 base `global.domain.jpa`(BaseEntity, db-core), `global.domain.security`(JwtProvider, jwt-core) — domain-core 가 아닌 인프라 모듈 + 이번에 지목된 id/file 이 아니므로 유지. (원하면 후속 PR 에서 정리 가능)

## 검증

- ✅ `./gradlew test` 전체 통과 (rename 후 전 모듈 컴파일 + 테스트)

## 참고

`gb-id-obfuscator` 모듈(스택 #16~#18)에 의존하므로 base 를 `refactor/distribute-config`(#20) 위에 스택했다. 앞 단계 머지 시 base 자동 재지정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
