### PR TITLE
refactor: 빙고 멤버 ID 응답/요청 필드 bingoMembers → bingoMemberIds

### DIFF
--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/request/BingoBoardMembersPeriodUpdateRequest.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/request/BingoBoardMembersPeriodUpdateRequest.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 class BingoBoardMembersPeriodUpdateRequest(
     @field:NotEmpty
     @field:EncryptId(ObfuscationType.MEMBER)
-    val bingoMembers: List<Long>,
+    val bingoMemberIds: List<Long>,
 
     val since: LocalDate,
 
@@ -18,6 +18,6 @@ class BingoBoardMembersPeriodUpdateRequest(
     val until: LocalDate
 ) {
     fun command(): BingoBoardMembersPeriodUpdateCommand {
-        return BingoBoardMembersPeriodUpdateCommand.of(bingoMembers, since, until)
+        return BingoBoardMembersPeriodUpdateCommand.of(bingoMemberIds, since, until)
     }
 }

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMembersPeriodUpdateResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/bingo/payload/response/BingoBoardMembersPeriodUpdateResponse.kt
@@ -9,7 +9,7 @@ class BingoBoardMembersPeriodUpdateResponse private constructor(
     @EncryptId(ObfuscationType.BINGO_BOARD)
     val id: Long,
     @EncryptId(ObfuscationType.MEMBER)
-    val bingoMembers: List<Long>,
+    val bingoMemberIds: List<Long>,
     val since: LocalDate?,
     val until: LocalDate?
 ) {
@@ -17,7 +17,7 @@ class BingoBoardMembersPeriodUpdateResponse private constructor(
         fun fromBingoBoard(board: BingoBoard): BingoBoardMembersPeriodUpdateResponse =
             BingoBoardMembersPeriodUpdateResponse(
                 id = board.id,
-                bingoMembers = board.bingoMembers.memberIds(),
+                bingoMemberIds = board.bingoMembers.memberIds(),
                 since = board.since,
                 until = board.until
             )

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardUpdateApiTest.kt
@@ -26,7 +26,7 @@ import com.beside.groubing.domain.common.id.ObfuscationType
 import com.beside.groubing.global.response.ApiResponse
 import com.beside.groubing.vocabulary.bingoBoardId
 import com.beside.groubing.vocabulary.bingoGoal
-import com.beside.groubing.vocabulary.bingoMembers
+import com.beside.groubing.vocabulary.bingoMemberIds
 import com.beside.groubing.vocabulary.bingoMemo
 import com.beside.groubing.vocabulary.bingoOpen
 import com.beside.groubing.vocabulary.bingoSince
@@ -141,13 +141,13 @@ class BingoBoardUpdateApiTest(
         }
 
         val bingoBoardMembersPeriodUpdateRequest = BingoBoardMembersPeriodUpdateRequest(
-            bingoMembers = listOf(2, 3, 7),
+            bingoMemberIds = listOf(2, 3, 7),
             since = LocalDate.now(),
             until = LocalDate.now().plusDays(7)
         )
         aEmptyBingo.updateBingoMembersPeriod(
             memberId,
-            bingoBoardMembersPeriodUpdateRequest.bingoMembers,
+            bingoBoardMembersPeriodUpdateRequest.bingoMemberIds,
             bingoBoardMembersPeriodUpdateRequest.since,
             bingoBoardMembersPeriodUpdateRequest.until
         )
@@ -169,7 +169,7 @@ class BingoBoardUpdateApiTest(
                 ApiResponse.OK(BingoBoardMembersPeriodUpdateResponse.fromBingoBoard(aEmptyBingo)),
                 "update-bingo-members-period",
                 requestBody(
-                    "bingoMembers" requestType ARRAY means
+                    "bingoMemberIds" requestType ARRAY means
                         "빙고 참여 멤버 ID 리스트 (각 요소는 obfuscated 문자열)" example
                         "[\"MEbN4aLpqRzK\", \"k9aQ2nWxRzVp\"]",
                     "since" requestType DATE means "빙고 시작 일자" example "2023-05-08",
@@ -177,7 +177,7 @@ class BingoBoardUpdateApiTest(
                 ),
                 responseBody(
                     bingoBoardId(),
-                    bingoMembers(),
+                    bingoMemberIds(),
                     bingoSince(),
                     bingoUntil()
                 )

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/BingoVocabulary.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/vocabulary/BingoVocabulary.kt
@@ -75,7 +75,7 @@ fun bingoColorValue(fieldName: String = "bingoColorValue") =
         "#B8B7FC" formattedAs
         "Blue : `#8BC0FC`, Orange: `#FCB179`, Red: `FF8282`, Green: `#55DEB5`, Purple : `#B8B7FC`"
 
-fun bingoMembers(fieldName: String = "bingoMembers") =
+fun bingoMemberIds(fieldName: String = "bingoMemberIds") =
     fieldName responseType ARRAY means
         "빙고 참여 멤버 ID 리스트 (각 요소는 obfuscated 문자열)" example
         "[\"MEbN4aLpqRzK\", \"k9aQ2nWxRzVp\"]"


### PR DESCRIPTION
## 배경

\`BingoBoardMembersPeriodUpdate\` 의 request/response 필드 \`bingoMembers: List<Long>\` 는 값이 **회원 id 리스트**(\`@EncryptId(MEMBER)\`, \`board.bingoMembers.memberIds()\`)인데, 이름이 "members"라 멤버 객체처럼 읽힌다.

## 변경

- 응답 \`BingoBoardMembersPeriodUpdateResponse.bingoMembers\` → \`bingoMemberIds\`
- 요청 \`BingoBoardMembersPeriodUpdateRequest.bingoMembers\` → \`bingoMemberIds\` (request 계약도 대칭 변경)
- REST Docs vocabulary \`bingoMembers()\` → \`bingoMemberIds()\`, \`BingoBoardUpdateApiTest\` 요청/응답 필드명 갱신

> 도메인 일급컬렉션 \`board.bingoMembers\`(멤버 객체 컬렉션)는 그대로 — DTO 필드(ID 리스트)만 변경.

## 네이밍 규칙 정렬

응답 DTO의 self 식별자는 \`id\`, 다른 애그리거트 참조는 \`<엔티티>Id\` 규칙에 맞춰 "ID 리스트"임을 필드명에 드러냄.

## 검증

- \`*BingoBoardUpdateApiTest*\` 통과 (REST Docs 스니펫 재생성)

## 참고

- API 응답/요청 계약(필드명) 변경 — 프론트 연동 시 동시 반영 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)