### PR TITLE
refactor: BlockedMemberResponse.id → memberId (회원 참조 네이밍 일관성)

### DIFF
--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/payload/response/BlockedMemberResponse.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/blockedmember/payload/response/BlockedMemberResponse.kt
@@ -7,7 +7,7 @@ import com.beside.groubing.global.id.EncryptId
 
 data class BlockedMemberResponse(
     @EncryptId(ObfuscationType.MEMBER)
-    val id: Long,
+    val memberId: Long,
     val email: String?,
     val nickname: String,
     val profileUrl: String?
@@ -15,7 +15,7 @@ data class BlockedMemberResponse(
     companion object {
         fun of(target: BlockedMemberTarget): BlockedMemberResponse {
             return BlockedMemberResponse(
-                id = target.id,
+                memberId = target.id,
                 email = target.email,
                 nickname = target.nickname,
                 profileUrl = FileInfo.urlOfOrNull(target.profileFileName)

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/BlockedMemberFindApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/blockedmember/api/BlockedMemberFindApiTest.kt
@@ -64,7 +64,7 @@ class BlockedMemberFindApiTest(
                 }.andDocument(
                     "blocked-member-find",
                     responseBody(
-                        targetMemberId("[].id"),
+                        targetMemberId("[].memberId"),
                         email("[].email"),
                         nickname("[].nickname"),
                         profileUrl("[].profileUrl"),


### PR DESCRIPTION
## 배경

PR #22(차단 해제를 대상 회원 id 기준으로 변경)로 \`BlockedMemberResponse.id\` 가 담는 값이 **차단 대상 회원 id**(다른 애그리거트 참조)가 됐다. 그런데 필드명은 \`id\` 그대로라, 다른 회원-참조 필드(\`memberId\`)와 어긋난다.

> 이 변경은 원래 PR #22에 함께 넣으려 했으나 #22가 먼저 머지되어 별도 PR로 분리합니다.

## 변경

- \`BlockedMemberResponse.id\` → \`memberId\` (\`@EncryptId(MEMBER)\`)
- REST Docs 응답 필드 경로 \`[].id\` → \`[].memberId\`

## 네이밍 규칙 정렬

self 식별자 = \`id\`, 다른 애그리거트 참조 = \`<엔티티>Id\`. 차단 목록의 각 항목 id는 대상 회원으로의 참조이므로 \`memberId\`.

## 검증

- \`*BlockedMemberFindApiTest*\` 통과 (REST Docs 스니펫 재생성)

## 참고

- API 응답 계약(필드명) 변경 — 프론트 연동 시 \`memberId\`로 동시 반영 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)