### PR TITLE
test: 도메인 레이어 단위 테스트 보강 (Bingo 애그리거트 · VO · Validator)

### DIFF
--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/auth/domain/PasswordVerifierTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/auth/domain/PasswordVerifierTest.kt
@@ -1,0 +1,39 @@
+package com.beside.groubing.domain.auth.domain
+
+import com.beside.groubing.domain.auth.domain.port.PasswordEncryptor
+import com.beside.groubing.domain.member.exception.MemberInputException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class PasswordVerifierTest : BehaviorSpec({
+    val passwordEncryptor = mockk<PasswordEncryptor>()
+    val verifier = PasswordVerifier(passwordEncryptor)
+
+    val rawPassword = "password123"
+    val encodedPassword = "encoded-password"
+
+    Given("입력한 비밀번호가 저장된 비밀번호와 일치할 때") {
+        every { passwordEncryptor.matches(rawPassword, encodedPassword) } returns true
+
+        When("verify 호출") {
+            Then("예외가 발생하지 않는다") {
+                verifier.verify(rawPassword, encodedPassword)
+            }
+        }
+    }
+
+    Given("입력한 비밀번호가 저장된 비밀번호와 일치하지 않을 때") {
+        every { passwordEncryptor.matches(rawPassword, encodedPassword) } returns false
+
+        When("verify 호출") {
+            Then("MemberInputException 이 발생한다") {
+                shouldThrow<MemberInputException> {
+                    verifier.verify(rawPassword, encodedPassword)
+                }.message shouldBe "비밀번호가 일치하지 않습니다."
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/auth/domain/SignUpValidatorTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/auth/domain/SignUpValidatorTest.kt
@@ -1,0 +1,78 @@
+package com.beside.groubing.domain.auth.domain
+
+import com.beside.groubing.domain.member.domain.MemberRole
+import com.beside.groubing.domain.member.domain.MemberType
+import com.beside.groubing.domain.member.domain.NewMember
+import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
+import com.beside.groubing.domain.member.exception.MemberInputException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class SignUpValidatorTest : BehaviorSpec({
+    val memberQueryRepository = mockk<MemberQueryRepository>()
+    val validator = SignUpValidator(memberQueryRepository)
+
+    fun newMember(
+        loginId: String? = "groubing",
+        nickname: String = "그루빙"
+    ) = NewMember(
+        loginId = loginId,
+        password = "password123",
+        nickname = nickname,
+        role = MemberRole.MEMBER,
+        memberType = MemberType.CLASSIC
+    )
+
+    Given("loginId 와 nickname 모두 중복되지 않을 때") {
+        val member = newMember()
+        every { memberQueryRepository.existsByLoginId(member.loginId!!) } returns false
+        every { memberQueryRepository.existsByNickname(member.nickname) } returns false
+
+        When("validate 호출") {
+            Then("예외가 발생하지 않는다") {
+                validator.validate(member)
+            }
+        }
+    }
+
+    Given("loginId 가 null 일 때 (소셜 가입 등)") {
+        val member = newMember(loginId = null)
+        every { memberQueryRepository.existsByNickname(member.nickname) } returns false
+
+        When("validate 호출") {
+            Then("loginId 중복 검사를 건너뛰고 예외가 발생하지 않는다") {
+                validator.validate(member)
+            }
+        }
+    }
+
+    Given("이미 사용 중인 loginId 일 때") {
+        val member = newMember()
+        every { memberQueryRepository.existsByLoginId(member.loginId!!) } returns true
+
+        When("validate 호출") {
+            Then("MemberInputException 이 발생한다") {
+                shouldThrow<MemberInputException> {
+                    validator.validate(member)
+                }.message shouldBe "이미 사용 중인 아이디입니다."
+            }
+        }
+    }
+
+    Given("loginId 는 사용 가능하지만 nickname 이 이미 사용 중일 때") {
+        val member = newMember()
+        every { memberQueryRepository.existsByLoginId(member.loginId!!) } returns false
+        every { memberQueryRepository.existsByNickname(member.nickname) } returns true
+
+        When("validate 호출") {
+            Then("MemberInputException 이 발생한다") {
+                shouldThrow<MemberInputException> {
+                    validator.validate(member)
+                }.message shouldBe "이미 사용 중인 닉네임 입니다."
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoardMembersValidatorTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoardMembersValidatorTest.kt
@@ -1,0 +1,49 @@
+package com.beside.groubing.domain.bingo.domain
+
+import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
+import com.beside.groubing.domain.member.exception.MemberInputException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class BingoBoardMembersValidatorTest : BehaviorSpec({
+    val memberQueryRepository = mockk<MemberQueryRepository>()
+    val validator = BingoBoardMembersValidator(memberQueryRepository)
+
+    Given("입력된 모든 ID 가 존재하는 회원일 때") {
+        val memberIds = listOf(1L, 2L, 3L)
+        every { memberQueryRepository.count(memberIds) } returns memberIds.size
+
+        When("validate 호출") {
+            Then("예외가 발생하지 않는다") {
+                validator.validate(memberIds)
+            }
+        }
+    }
+
+    Given("입력된 ID 중 존재하지 않는 회원이 있을 때") {
+        val memberIds = listOf(1L, 2L, 3L)
+        every { memberQueryRepository.count(memberIds) } returns memberIds.size - 1
+
+        When("validate 호출") {
+            Then("MemberInputException 이 발생한다") {
+                shouldThrow<MemberInputException> {
+                    validator.validate(memberIds)
+                }.message shouldBe "입력된 ID 중 존재하지 않는 회원이 있습니다. memberIds:$memberIds"
+            }
+        }
+    }
+
+    Given("빈 memberIds 가 입력될 때") {
+        val memberIds = emptyList<Long>()
+        every { memberQueryRepository.count(memberIds) } returns 0
+
+        When("validate 호출") {
+            Then("count 와 size 가 모두 0 으로 일치하여 예외가 발생하지 않는다") {
+                validator.validate(memberIds)
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoardTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoardTest.kt
@@ -1,7 +1,19 @@
 package com.beside.groubing.domain.bingo.domain
 
+import com.beside.groubing.domain.bingo.event.BingoCompleteEvent
+import com.beside.groubing.domain.bingo.event.BingoLineCancelEvent
+import com.beside.groubing.domain.bingo.event.BingoLineCompleteEvent
+import com.beside.groubing.domain.bingo.exception.BingoIllegalStateException
+import com.beside.groubing.domain.bingo.exception.BingoInputException
+import com.beside.groubing.domain.bingo.fixture.BingoBoardFixture
+import com.beside.groubing.domain.bingo.fixture.BingoBoardFixture.LEADER_ID
+import com.beside.groubing.domain.bingo.fixture.BingoBoardFixture.PARTICIPANT_ID
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.enum
@@ -9,8 +21,17 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.single
 import io.kotest.property.arbitrary.string
+import java.time.LocalDate
 
+/**
+ * 3x3 보드 기준 itemOrder ↔ 위치 매핑 (Fixture 가 itemOrder 1..9 로 고정):
+ *   order 1 2 3   (가로 1번 라인)
+ *   order 4 5 6   (가로 2번 라인)
+ *   order 7 8 9   (가로 3번 라인)
+ * BingoItem.id == itemOrder 로 1:1 매핑되므로 itemId 1,2,3 완료 시 가로 1번 라인 빙고가 성립한다.
+ */
 class BingoBoardTest : BehaviorSpec({
+
     Given("신규 보드 생성 시") {
         val memberId = Arb.long().single()
         val bingoSize = Arb.int(3..4).single()
@@ -28,6 +49,443 @@ class BingoBoardTest : BehaviorSpec({
 
             Then("빙고 아이템을 생성한다.") {
                 items.size shouldBe (board.size * board.size)
+            }
+
+            Then("생성자를 리더로 등록한다.") {
+                board.isLeader(memberId) shouldBe true
+            }
+
+            Then("초기 상태는 임시 빙고(기간 미설정)이며 활성 상태다.") {
+                board.period shouldBe null
+                board.isStarted() shouldBe false
+                board.active shouldBe true
+            }
+        }
+    }
+
+    Given("빙고 아이템 완료(completeBingoItem)") {
+        When("아직 임시 빙고(기간 미설정) 상태에서 완료하면") {
+            val board = BingoBoardFixture.temporaryBoard(allUpdated = true)
+
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    board.completeBingoItem(bingoItemId = 1L, memberId = LEADER_ID)
+                }.message shouldBe "아직 임시빙고 상태에서 빙고를 완성할 수 없습니다."
+            }
+        }
+
+        When("시작된 빙고에서 라인을 완성하지 못하는 아이템 1개만 완료하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1)
+            board.completeBingoItem(bingoItemId = 1L, memberId = LEADER_ID)
+
+            Then("해당 아이템이 완료 처리된다.") {
+                board.bingoItems.findOf(1L).isCompleted(LEADER_ID) shouldBe true
+            }
+
+            Then("빙고 라인이 늘지 않았으므로 도메인 이벤트가 발생하지 않는다.") {
+                board.pullEvents().shouldHaveSize(0)
+            }
+        }
+
+        When("가로 한 줄(아이템 1,2,3)을 완료해 빙고 라인이 새로 생기면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+            board.completeBingoItem(bingoItemId = 1L, memberId = LEADER_ID)
+            board.completeBingoItem(bingoItemId = 2L, memberId = LEADER_ID)
+            board.completeBingoItem(bingoItemId = 3L, memberId = LEADER_ID)
+
+            Then("BingoLineCompleteEvent 가 1건 발생한다.") {
+                val events = board.pullEvents()
+                events.shouldHaveSize(1)
+                val event = events.single().shouldBeInstanceOf<BingoLineCompleteEvent>()
+                event.bingoBoardId shouldBe board.id
+                event.bingoBoardTitle shouldBe board.title
+                event.totalBingoCount shouldBe 1
+                event.memberId shouldBe LEADER_ID
+                event.otherMemberIds shouldContainExactlyInAnyOrder listOf(PARTICIPANT_ID)
+            }
+        }
+
+        When("목표 빙고 수를 이미 달성한 뒤 라인을 늘리지 않는 아이템을 완료하면") {
+            // goal=1, 가로 1번 라인(1,2,3) 완료로 이미 1빙고 달성. 그 후 아이템 9(라인 미완성) 완료 →
+            // afterBingoCount == beforeBingoCount && isGoal(after) 분기를 탄다.
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+            board.completeBingoItem(bingoItemId = 1L, memberId = LEADER_ID)
+            board.completeBingoItem(bingoItemId = 2L, memberId = LEADER_ID)
+            board.completeBingoItem(bingoItemId = 3L, memberId = LEADER_ID)
+            board.pullEvents() // 라인 완성 이벤트 비우기
+            board.completeBingoItem(bingoItemId = 9L, memberId = LEADER_ID)
+
+            Then("BingoCompleteEvent 가 1건 발생한다.") {
+                val events = board.pullEvents()
+                events.shouldHaveSize(1)
+                val event = events.single().shouldBeInstanceOf<BingoCompleteEvent>()
+                event.bingoBoardId shouldBe board.id
+                event.bingoBoardTitle shouldBe board.title
+                event.memberId shouldBe LEADER_ID
+                event.otherMemberIds shouldContainExactlyInAnyOrder listOf(PARTICIPANT_ID)
+            }
+        }
+
+        When("이미 완료한 아이템을 다시 완료하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1)
+            board.completeBingoItem(bingoItemId = 1L, memberId = LEADER_ID)
+
+            Then("IllegalStateException 이 발생한다.") {
+                shouldThrow<IllegalStateException> {
+                    board.completeBingoItem(bingoItemId = 1L, memberId = LEADER_ID)
+                }
+            }
+        }
+
+        When("존재하지 않는 아이템 아이디로 완료하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1)
+
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    board.completeBingoItem(bingoItemId = 999L, memberId = LEADER_ID)
+                }.message shouldBe "입력된 빙고 아이템 아이디가 잘못 되었습니다. id : 999"
+            }
+        }
+    }
+
+    Given("빙고 아이템 완료 취소(cancelBingoItem)") {
+        When("아직 임시 빙고 상태에서 취소하면") {
+            val board = BingoBoardFixture.temporaryBoard(allUpdated = true)
+
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    board.cancelBingoItem(bingoItemId = 1L, memberId = LEADER_ID)
+                }.message shouldBe "아직 임시빙고 상태에서 빙고를 취소할 수 없습니다."
+            }
+        }
+
+        When("완성된 빙고 라인을 깨뜨리는 아이템을 취소하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+            board.completeBingoItem(bingoItemId = 1L, memberId = LEADER_ID)
+            board.completeBingoItem(bingoItemId = 2L, memberId = LEADER_ID)
+            board.completeBingoItem(bingoItemId = 3L, memberId = LEADER_ID)
+            board.pullEvents() // 완성 이벤트 비우기
+            board.cancelBingoItem(bingoItemId = 2L, memberId = LEADER_ID)
+
+            Then("해당 아이템 완료가 해제된다.") {
+                board.bingoItems.findOf(2L).isCompleted(LEADER_ID) shouldBe false
+            }
+
+            Then("BingoLineCancelEvent 가 1건 발생한다.") {
+                val events = board.pullEvents()
+                events.shouldHaveSize(1)
+                val event = events.single().shouldBeInstanceOf<BingoLineCancelEvent>()
+                event.bingoBoardId shouldBe board.id
+                event.bingoItemTitle shouldBe board.bingoItems.findOf(2L).title
+                event.memberId shouldBe LEADER_ID
+                event.otherMemberIds shouldContainExactlyInAnyOrder listOf(PARTICIPANT_ID)
+            }
+        }
+
+        When("빙고 라인을 깨뜨리지 않는 아이템을 취소하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1)
+            board.completeBingoItem(bingoItemId = 5L, memberId = LEADER_ID)
+            board.pullEvents()
+            board.cancelBingoItem(bingoItemId = 5L, memberId = LEADER_ID)
+
+            Then("도메인 이벤트가 발생하지 않는다.") {
+                board.pullEvents().shouldHaveSize(0)
+            }
+        }
+    }
+
+    Given("빙고 아이템 셔플(shuffleBingoItems)") {
+        When("임시 빙고(아직 시작 전) 상태에서 셔플하면") {
+            val board = BingoBoardFixture.temporaryBoard(size = 3, allUpdated = false)
+            val beforeImageUrls = board.bingoItems.map { it.imageUrl }.sorted()
+
+            board.shuffleBingoItems()
+
+            Then("아이템 개수와 imageUrl 구성은 보존된다.") {
+                board.bingoItems.map { it.imageUrl }.sorted() shouldBe beforeImageUrls
+            }
+
+            Then("itemOrder 는 1..N 으로 빠짐없이 재배치된다.") {
+                board.bingoItems.map { it.itemOrder }.sorted() shouldBe (1..(board.size * board.size)).toList()
+            }
+        }
+
+        When("이미 시작된 빙고에서 셔플하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3)
+
+            Then("BingoInputException 이 발생한다.") {
+                shouldThrow<BingoInputException> {
+                    board.shuffleBingoItems()
+                }.message shouldBe "임시 빙고가 아니면 shuffle 할 수 없습니다. BingoBoard Id : ${board.id}"
+            }
+        }
+    }
+
+    Given("기본 정보 수정(updateBase)") {
+        val newSince = LocalDate.now()
+        val newUntil = LocalDate.now().plusDays(30)
+
+        When("리더가 수정하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1)
+            board.updateBase(memberId = LEADER_ID, title = "변경된 제목", goal = 2, since = newSince, until = newUntil)
+
+            Then("제목/목표/기간이 갱신된다.") {
+                board.title shouldBe "변경된 제목"
+                board.goal shouldBe 2
+                board.since shouldBe newSince
+                board.until shouldBe newUntil
+            }
+        }
+
+        When("리더가 아닌 참여자가 수정하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    board.updateBase(memberId = PARTICIPANT_ID, title = "x", goal = 1, since = newSince, until = newUntil)
+                }.message shouldBe "해당 빙고를 수정할 권한이 없습니다."
+            }
+        }
+
+        When("빙고에 포함되지 않은 회원이 수정하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1)
+
+            Then("BingoInputException 이 발생한다.") {
+                shouldThrow<BingoInputException> {
+                    board.updateBase(memberId = 999L, title = "x", goal = 1, since = newSince, until = newUntil)
+                }
+            }
+        }
+    }
+
+    Given("아이템 내용 수정(updateBingoItem)") {
+        When("리더가 아이템 제목/부제목을 수정하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1)
+            val updated = board.updateBingoItem(memberId = LEADER_ID, bingoItemId = 1L, title = "새 제목", subTitle = "부제목")
+
+            Then("아이템 내용이 갱신되어 반환된다.") {
+                updated.title shouldBe "새 제목"
+                updated.subTitle shouldBe "부제목"
+                board.bingoItems.findOf(1L).title shouldBe "새 제목"
+            }
+        }
+
+        When("리더가 아닌 회원이 아이템을 수정하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    board.updateBingoItem(memberId = PARTICIPANT_ID, bingoItemId = 1L, title = "x", subTitle = null)
+                }
+            }
+        }
+    }
+
+    Given("멤버/기간 수정(updateBingoMembersPeriod)") {
+        val since = LocalDate.now()
+        val until = LocalDate.now().plusDays(10)
+
+        When("리더가 새 멤버와 기간을 등록하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1)
+            board.updateBingoMembersPeriod(memberId = LEADER_ID, bingoMembers = listOf(3L, 4L), since = since, until = until)
+
+            Then("기간이 갱신되고 새 멤버가 추가된다.") {
+                board.since shouldBe since
+                board.until shouldBe until
+                board.bingoMembers.memberIds() shouldContainExactlyInAnyOrder listOf(LEADER_ID, 3L, 4L)
+            }
+        }
+
+        When("리더가 아닌 회원이 멤버/기간을 수정하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    board.updateBingoMembersPeriod(memberId = PARTICIPANT_ID, bingoMembers = listOf(3L), since = since, until = until)
+                }
+            }
+        }
+    }
+
+    Given("메모 수정(updateBingoMemo)") {
+        When("리더가 메모를 수정하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1)
+            board.updateBingoMemo(memberId = LEADER_ID, memo = "오늘의 메모")
+
+            Then("메모가 갱신된다.") {
+                board.memo shouldBe "오늘의 메모"
+            }
+        }
+
+        When("리더가 아닌 회원이 메모를 수정하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    board.updateBingoMemo(memberId = PARTICIPANT_ID, memo = "x")
+                }
+            }
+        }
+    }
+
+    Given("공개 여부 수정(updateBingoOpen)") {
+        When("리더가 공개 여부를 변경하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, open = true)
+            board.updateBingoOpen(memberId = LEADER_ID, open = false)
+
+            Then("공개 여부가 갱신된다.") {
+                board.open shouldBe false
+            }
+        }
+
+        When("리더가 아닌 회원이 공개 여부를 변경하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    board.updateBingoOpen(memberId = PARTICIPANT_ID, open = false)
+                }
+            }
+        }
+    }
+
+    Given("빙고 삭제(delete)") {
+        When("삭제하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1)
+            board.delete()
+
+            Then("비활성 상태가 된다.") {
+                board.active shouldBe false
+            }
+        }
+    }
+
+    Given("빙고 나가기 검증(validateCanLeave)") {
+        When("리더가 나가려 하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    board.validateCanLeave(LEADER_ID)
+                }.message shouldBe "그룹 빙고 리더는 빙고를 나갈 수 없습니다."
+            }
+        }
+
+        When("참여자가 나가려 하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+
+            Then("예외가 발생하지 않는다.") {
+                board.validateCanLeave(PARTICIPANT_ID)
+            }
+        }
+    }
+
+    Given("멤버 탈퇴 처리(inactiveByMemberId)") {
+        When("완료 기록이 있는 참여자가 탈퇴하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+            board.completeBingoItem(bingoItemId = 1L, memberId = PARTICIPANT_ID)
+            board.inactiveByMemberId(PARTICIPANT_ID)
+
+            Then("해당 회원은 활성 다른 멤버 목록에서 제외된다.") {
+                board.otherActiveMemberIdsOf(LEADER_ID).shouldHaveSize(0)
+            }
+
+            Then("해당 회원의 완료 기록도 비활성화된다.") {
+                val completeMember = board.bingoItems.findOf(1L).getBingoCompleteMember(PARTICIPANT_ID)
+                completeMember!!.active shouldBe false
+            }
+        }
+    }
+
+    Given("권한/리더 조회") {
+        val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+
+        When("리더에 대해 isLeader 를 호출하면") {
+            Then("true 를 반환한다.") {
+                board.isLeader(LEADER_ID) shouldBe true
+            }
+        }
+
+        When("참여자에 대해 isLeader 를 호출하면") {
+            Then("false 를 반환한다.") {
+                board.isLeader(PARTICIPANT_ID) shouldBe false
+            }
+        }
+
+        When("참여자가 validateAuthority 를 호출하면") {
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    board.validateAuthority(PARTICIPANT_ID)
+                }
+            }
+        }
+    }
+
+    Given("열람 권한 검증(validateViewableBy)") {
+        When("리더가 임시 빙고를 열람하면") {
+            val board = BingoBoardFixture.temporaryBoard(participantIds = listOf(PARTICIPANT_ID))
+
+            Then("예외가 발생하지 않는다.") {
+                board.validateViewableBy(LEADER_ID)
+            }
+        }
+
+        When("참여자가 아직 시작되지 않은 임시 빙고를 열람하면") {
+            val board = BingoBoardFixture.temporaryBoard(participantIds = listOf(PARTICIPANT_ID))
+
+            Then("BingoInputException 이 발생한다.") {
+                shouldThrow<BingoInputException> {
+                    board.validateViewableBy(PARTICIPANT_ID)
+                }.message shouldBe "접근할 수 없는 빙고보드입니다."
+            }
+        }
+
+        When("참여자가 이미 시작된 빙고를 열람하면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1, participantIds = listOf(PARTICIPANT_ID))
+
+            Then("예외가 발생하지 않는다.") {
+                board.validateViewableBy(PARTICIPANT_ID)
+            }
+        }
+    }
+
+    Given("남은 기간 계산(calculateLeftDays)") {
+        When("종료일이 이미 지난 빙고이면") {
+            val board = BingoBoardFixture.startedBoard(size = 3, goal = 1)
+            // 종료일을 과거로 만들기 위해 of 로 직접 만료 기간을 주입한다.
+            val expired = BingoBoard.of(
+                id = 1L,
+                title = board.title,
+                boardType = BingoBoardType.GROUP,
+                bingoColor = BingoColor.BLUE,
+                open = true,
+                memo = null,
+                active = true,
+                bingoSize = BingoSize.cache(3),
+                bingoGoal = BingoGoal.create(1, BingoSize.cache(3)),
+                period = BingoPeriod.of(
+                    LocalDate.now().minusDays(10),
+                    LocalDate.now().minusDays(1)
+                ),
+                bingoMembers = BingoBoardFixture.bingoMembers(),
+                bingoItems = BingoBoardFixture.bingoItems(3, updated = true)
+            )
+
+            Then("음수가 아닌 0 으로 보정된다.") {
+                expired.calculateLeftDays() shouldBe 0L
+            }
+
+            Then("isFinished 는 true 다.") {
+                expired.isFinished() shouldBe true
+            }
+        }
+
+        When("기간이 설정되지 않은 임시 빙고이면") {
+            val board = BingoBoardFixture.temporaryBoard()
+
+            Then("남은 기간은 0 이고 isFinished 는 false 다.") {
+                board.calculateLeftDays() shouldBe 0L
+                board.isFinished() shouldBe false
             }
         }
     }

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoCompleteMemberTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoCompleteMemberTest.kt
@@ -1,0 +1,29 @@
+package com.beside.groubing.domain.bingo.domain
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class BingoCompleteMemberTest : BehaviorSpec({
+
+    Given("BingoCompleteMember.create") {
+        When("memberId 로 생성하면") {
+            val completeMember = BingoCompleteMember.create(memberId = 1L)
+
+            Then("활성 상태로 생성된다.") {
+                completeMember.memberId shouldBe 1L
+                completeMember.active shouldBe true
+            }
+        }
+    }
+
+    Given("inactive") {
+        When("활성 완료 멤버를 비활성화하면") {
+            val completeMember = BingoCompleteMember.create(memberId = 1L)
+            completeMember.inactive()
+
+            Then("active 가 false 가 된다.") {
+                completeMember.active shouldBe false
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoGoalTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoGoalTest.kt
@@ -1,0 +1,76 @@
+package com.beside.groubing.domain.bingo.domain
+
+import com.beside.groubing.domain.bingo.exception.BingoInputException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class BingoGoalTest : BehaviorSpec({
+
+    Given("3x3(최대 목표 8) 빙고 사이즈에서 BingoGoal 을 생성할 때") {
+        val bingoSize = BingoSize.cache(3)
+
+        When("최소값 1로 생성하면") {
+            val bingoGoal = BingoGoal.create(1, bingoSize)
+
+            Then("goal 이 1인 객체가 생성된다") {
+                bingoGoal.goal shouldBe 1
+            }
+        }
+
+        When("최대값(maxGoal) 8로 생성하면") {
+            val bingoGoal = BingoGoal.create(bingoSize.getMaxGoal(), bingoSize)
+
+            Then("goal 이 8인 객체가 생성된다") {
+                bingoGoal.goal shouldBe 8
+            }
+        }
+
+        When("0으로 생성하면") {
+            Then("BingoInputException 이 발생한다") {
+                shouldThrow<BingoInputException> {
+                    BingoGoal.create(0, bingoSize)
+                }
+            }
+        }
+
+        When("음수로 생성하면") {
+            Then("BingoInputException 이 발생한다") {
+                shouldThrow<BingoInputException> {
+                    BingoGoal.create(-1, bingoSize)
+                }
+            }
+        }
+
+        When("최대 목표(8)를 초과한 9로 생성하면") {
+            Then("BingoInputException 이 발생한다") {
+                shouldThrow<BingoInputException> {
+                    BingoGoal.create(bingoSize.getMaxGoal() + 1, bingoSize)
+                }
+            }
+        }
+    }
+
+    Given("isGoal 판정") {
+        val bingoSize = BingoSize.cache(3)
+        val bingoGoal = BingoGoal.create(3, bingoSize)
+
+        When("빙고 개수가 목표(3)와 같으면") {
+            Then("true 를 반환한다") {
+                bingoGoal.isGoal(3) shouldBe true
+            }
+        }
+
+        When("빙고 개수가 목표보다 작으면") {
+            Then("false 를 반환한다") {
+                bingoGoal.isGoal(2) shouldBe false
+            }
+        }
+
+        When("빙고 개수가 목표보다 크면") {
+            Then("false 를 반환한다") {
+                bingoGoal.isGoal(4) shouldBe false
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoItemTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoItemTest.kt
@@ -1,0 +1,147 @@
+package com.beside.groubing.domain.bingo.domain
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class BingoItemTest : BehaviorSpec({
+
+    val memberId = 1L
+
+    fun newItem(): BingoItem = BingoItem.create(itemOrder = 1, imageUrl = "g")
+
+    Given("BingoItem.create") {
+        When("itemOrder 와 imageUrl 로 생성하면") {
+            val item = newItem()
+
+            Then("title 이 비어있어 isUpdated 가 false 다.") {
+                item.title shouldBe null
+                item.isUpdated() shouldBe false
+            }
+
+            Then("완료한 멤버가 없다.") {
+                item.completeMembers.shouldHaveSize(0)
+            }
+        }
+    }
+
+    Given("complete") {
+        When("완료한 적 없는 회원이 완료하면") {
+            val item = newItem()
+            item.complete(memberId)
+
+            Then("해당 회원이 완료 멤버로 등록된다.") {
+                item.isCompleted(memberId) shouldBe true
+                item.completeMembers.shouldHaveSize(1)
+            }
+        }
+
+        When("이미 완료한 회원이 다시 완료하면") {
+            val item = newItem()
+            item.complete(memberId)
+
+            Then("IllegalStateException 이 발생한다.") {
+                shouldThrow<IllegalStateException> {
+                    item.complete(memberId)
+                }
+            }
+        }
+
+        When("서로 다른 회원이 각각 완료하면") {
+            val item = newItem()
+            item.complete(1L)
+            item.complete(2L)
+
+            Then("두 회원 모두 완료 상태로 등록된다.") {
+                item.isCompleted(1L) shouldBe true
+                item.isCompleted(2L) shouldBe true
+                item.completeMembers.shouldHaveSize(2)
+            }
+        }
+    }
+
+    Given("cancel") {
+        When("완료한 회원이 취소하면") {
+            val item = newItem()
+            item.complete(memberId)
+            item.cancel(memberId)
+
+            Then("완료 상태가 해제된다.") {
+                item.isCompleted(memberId) shouldBe false
+                item.completeMembers.shouldHaveSize(0)
+            }
+        }
+
+        When("완료한 적 없는 회원이 취소하면") {
+            val item = newItem()
+            item.cancel(memberId)
+
+            Then("아무 변화 없이 완료 멤버가 비어있다.") {
+                item.completeMembers.shouldHaveSize(0)
+            }
+        }
+    }
+
+    Given("update") {
+        When("title 과 subTitle 을 수정하면") {
+            val item = newItem()
+            item.update(title = "제목", subTitle = "부제목")
+
+            Then("내용이 갱신되고 isUpdated 가 true 가 된다.") {
+                item.title shouldBe "제목"
+                item.subTitle shouldBe "부제목"
+                item.isUpdated() shouldBe true
+            }
+        }
+    }
+
+    Given("changeItemOrder") {
+        When("itemOrder 를 변경하면") {
+            val item = newItem()
+            item.changeItemOrder(5)
+
+            Then("순서가 갱신된다.") {
+                item.itemOrder shouldBe 5
+            }
+        }
+    }
+
+    Given("getImageUrl") {
+        When("완료하지 않은 회원에 대해 호출하면") {
+            val item = newItem()
+
+            Then("기본 이미지 경로를 반환한다.") {
+                item.getImageUrl(memberId) shouldBe "g${BingoItem.EXTENSION}"
+            }
+        }
+
+        When("완료한 회원에 대해 호출하면") {
+            val item = newItem()
+            item.complete(memberId)
+
+            Then("완료 이미지 경로를 반환한다.") {
+                item.getImageUrl(memberId) shouldBe "g_complete${BingoItem.EXTENSION}"
+            }
+        }
+    }
+
+    Given("getBingoCompleteMember") {
+        When("완료한 회원으로 조회하면") {
+            val item = newItem()
+            item.complete(memberId)
+
+            Then("해당 완료 멤버를 반환한다.") {
+                item.getBingoCompleteMember(memberId)!!.memberId shouldBe memberId
+            }
+        }
+
+        When("완료하지 않은 회원으로 조회하면") {
+            val item = newItem()
+
+            Then("null 을 반환한다.") {
+                item.getBingoCompleteMember(memberId) shouldBe null
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoItemsTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoItemsTest.kt
@@ -1,0 +1,124 @@
+package com.beside.groubing.domain.bingo.domain
+
+import com.beside.groubing.domain.bingo.exception.BingoIllegalStateException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class BingoItemsTest : BehaviorSpec({
+
+    fun items(size: Int = 3, updated: Boolean = true): BingoItems {
+        val total = size * size
+        return BingoItems.of(
+            (1..total).map { order ->
+                BingoItem.of(
+                    id = order.toLong(),
+                    title = if (updated) "item-$order" else null,
+                    subTitle = null,
+                    imageUrl = "g",
+                    itemOrder = order,
+                    colorCode = "#2787C9",
+                    completeMembers = mutableSetOf()
+                )
+            }
+        )
+    }
+
+    Given("BingoItems.create") {
+        When("boardSize 와 알파벳 목록으로 생성하면") {
+            val alphabets = listOf("g", "r", "o", "u", "b", "i", "n", "g2", "r2")
+            val bingoItems = BingoItems.create(boardSize = 3, alphabets = alphabets)
+
+            Then("size*size 개의 아이템이 생성된다.") {
+                bingoItems.size shouldBe 9
+            }
+
+            Then("itemOrder 는 1..9 로 채워진다.") {
+                bingoItems.map { it.itemOrder }.sorted() shouldBe (1..9).toList()
+            }
+
+            Then("초기 생성 아이템은 title 이 비어 isUpdated 가 아니다.") {
+                bingoItems.isAllUpdated() shouldBe false
+            }
+        }
+    }
+
+    Given("findOf") {
+        val bingoItems = items()
+
+        When("존재하는 아이템 아이디로 조회하면") {
+            Then("해당 아이템을 반환한다.") {
+                bingoItems.findOf(2L).id shouldBe 2L
+            }
+        }
+
+        When("존재하지 않는 아이템 아이디로 조회하면") {
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    bingoItems.findOf(999L)
+                }.message shouldBe "입력된 빙고 아이템 아이디가 잘못 되었습니다. id : 999"
+            }
+        }
+    }
+
+    Given("isAllUpdated") {
+        When("모든 아이템에 title 이 있으면") {
+            Then("true 를 반환한다.") {
+                items(updated = true).isAllUpdated() shouldBe true
+            }
+        }
+
+        When("title 이 없는 아이템이 하나라도 있으면") {
+            Then("false 를 반환한다.") {
+                items(updated = false).isAllUpdated() shouldBe false
+            }
+        }
+    }
+
+    Given("sortedByOrder") {
+        When("itemOrder 가 뒤섞인 아이템을 정렬하면") {
+            val unordered = BingoItems.of(
+                listOf(
+                    BingoItem.of(3L, "c", null, "g", 3, "#2787C9", mutableSetOf()),
+                    BingoItem.of(1L, "a", null, "g", 1, "#2787C9", mutableSetOf()),
+                    BingoItem.of(2L, "b", null, "g", 2, "#2787C9", mutableSetOf())
+                )
+            )
+
+            Then("itemOrder 오름차순으로 정렬된다.") {
+                unordered.sortedByOrder().map { it.itemOrder } shouldBe listOf(1, 2, 3)
+            }
+        }
+    }
+
+    Given("completeMembersOf") {
+        val bingoItems = items()
+
+        When("일부 아이템만 해당 회원이 완료한 상태에서 조회하면") {
+            val memberId = 1L
+            bingoItems.findOf(1L).complete(memberId)
+
+            Then("아이템 개수만큼 결과가 나오되 완료하지 않은 칸은 null 이다.") {
+                val result = bingoItems.completeMembersOf(memberId)
+                result.shouldHaveSize(bingoItems.size)
+                result.count { it != null } shouldBe 1
+            }
+        }
+    }
+
+    Given("shuffle") {
+        When("아이템을 셔플하면") {
+            val bingoItems = items(size = 3)
+            bingoItems.shuffle()
+
+            Then("아이템 개수는 유지된다.") {
+                bingoItems.size shouldBe 9
+            }
+
+            Then("itemOrder 는 1..9 로 빠짐없이 재배치된다.") {
+                bingoItems.map { it.itemOrder }.sorted() shouldBe (1..9).toList()
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoMapTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoMapTest.kt
@@ -1,46 +1,270 @@
 package com.beside.groubing.domain.bingo.domain
 
 import com.beside.groubing.domain.bingo.domain.map.BingoMap
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import com.beside.groubing.domain.bingo.domain.map.Direction
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 
-class BingoMapTest {
+class BingoMapTest : BehaviorSpec({
+    val memberId = 1L
 
-    @Test
-    fun `Test calculateTotalBingoCount`() {
-        val bingoSize = 3
-        val bingoItems = (0 until (bingoSize * bingoSize)).map { BingoItem.create(it, imageUrl = "g") }
-        val memberId = 1L
-        val bingoMap = BingoMap(memberId, bingoSize, bingoItems)
+    fun createItems(bingoSize: Int): List<BingoItem> =
+        (0 until (bingoSize * bingoSize)).map { BingoItem.create(it, imageUrl = "g") }
 
-        // no complete
-        assertEquals(0, bingoMap.calculateTotalBingoCount())
-
-        // horizontal bingo
-        bingoItems[0].completeMembers.add(BingoCompleteMember.create(memberId))
-        bingoItems[1].completeMembers.add(BingoCompleteMember.create(memberId))
-        bingoItems[2].completeMembers.add(BingoCompleteMember.create(memberId))
-        assertEquals(1, bingoMap.calculateTotalBingoCount())
-
-        // vertical bingo
-        bingoItems[3].completeMembers.add(BingoCompleteMember.create(memberId))
-        bingoItems[6].completeMembers.add(BingoCompleteMember.create(memberId))
-        assertEquals(2, bingoMap.calculateTotalBingoCount())
-
-        // diagonal bingo
-        bingoItems[4].completeMembers.add(BingoCompleteMember.create(memberId))
-        bingoItems[8].completeMembers.add(BingoCompleteMember.create(memberId))
-        assertEquals(4, bingoMap.calculateTotalBingoCount())
-
-        // all complete
-        bingoItems[1].completeMembers.add(BingoCompleteMember.create(memberId))
-        bingoItems[2].completeMembers.add(BingoCompleteMember.create(memberId))
-        bingoItems[3].completeMembers.add(BingoCompleteMember.create(memberId))
-        bingoItems[4].completeMembers.add(BingoCompleteMember.create(memberId))
-        bingoItems[5].completeMembers.add(BingoCompleteMember.create(memberId))
-        bingoItems[6].completeMembers.add(BingoCompleteMember.create(memberId))
-        bingoItems[7].completeMembers.add(BingoCompleteMember.create(memberId))
-        bingoItems[8].completeMembers.add(BingoCompleteMember.create(memberId))
-        assertEquals(8, bingoMap.calculateTotalBingoCount())
+    fun List<BingoItem>.complete(memberId: Long, vararg indexes: Int) {
+        indexes.forEach { this[it].complete(memberId) }
     }
-}
+
+    Given("3x3 빙고맵에서 완료된 아이템이 하나도 없을 때") {
+        val items = createItems(3)
+        val bingoMap = BingoMap(memberId, 3, items)
+
+        When("총 빙고 개수를 계산하면") {
+            val count = bingoMap.calculateTotalBingoCount()
+
+            Then("0개가 반환된다") {
+                count shouldBe 0
+            }
+        }
+    }
+
+    Given("3x3 빙고맵에서 가로 한 줄(0,1,2)이 완료되었을 때") {
+        val items = createItems(3)
+        items.complete(memberId, 0, 1, 2)
+        val bingoMap = BingoMap(memberId, 3, items)
+
+        When("총 빙고 개수를 계산하면") {
+            val count = bingoMap.calculateTotalBingoCount()
+
+            Then("가로 빙고 1개가 인식된다") {
+                count shouldBe 1
+            }
+        }
+
+        When("가로 방향 빙고 인덱스를 조회하면") {
+            val indexes = bingoMap.getBingoIndexes(Direction.HORIZONTAL)
+
+            Then("첫 번째 가로 줄(0번 인덱스)만 반환된다") {
+                indexes shouldBe listOf(0)
+            }
+        }
+    }
+
+    Given("3x3 빙고맵에서 세로 한 줄(0,3,6)이 완료되었을 때") {
+        val items = createItems(3)
+        items.complete(memberId, 0, 3, 6)
+        val bingoMap = BingoMap(memberId, 3, items)
+
+        When("총 빙고 개수를 계산하면") {
+            val count = bingoMap.calculateTotalBingoCount()
+
+            Then("세로 빙고 1개가 인식된다") {
+                count shouldBe 1
+            }
+        }
+
+        When("세로 방향 빙고 인덱스를 조회하면") {
+            val indexes = bingoMap.getBingoIndexes(Direction.VERTICAL)
+
+            Then("첫 번째 세로 줄(0번 인덱스)만 반환된다") {
+                indexes shouldBe listOf(0)
+            }
+        }
+    }
+
+    Given("3x3 빙고맵에서 좌상-우하 대각선(0,4,8)이 완료되었을 때") {
+        val items = createItems(3)
+        items.complete(memberId, 0, 4, 8)
+        val bingoMap = BingoMap(memberId, 3, items)
+
+        When("총 빙고 개수를 계산하면") {
+            val count = bingoMap.calculateTotalBingoCount()
+
+            Then("대각선 빙고 1개가 인식된다") {
+                count shouldBe 1
+            }
+        }
+
+        When("대각선 방향 빙고 인덱스를 조회하면") {
+            val indexes = bingoMap.getBingoIndexes(Direction.DIAGONAL)
+
+            Then("첫 번째 대각선(0번 인덱스)만 반환된다") {
+                indexes shouldBe listOf(0)
+            }
+        }
+    }
+
+    Given("3x3 빙고맵에서 우상-좌하 대각선(2,4,6)이 완료되었을 때") {
+        val items = createItems(3)
+        items.complete(memberId, 2, 4, 6)
+        val bingoMap = BingoMap(memberId, 3, items)
+
+        When("대각선 방향 빙고 인덱스를 조회하면") {
+            val indexes = bingoMap.getBingoIndexes(Direction.DIAGONAL)
+
+            Then("두 번째 대각선(1번 인덱스)만 반환된다") {
+                indexes shouldBe listOf(1)
+            }
+        }
+    }
+
+    Given("3x3 빙고맵에서 가로/세로/두 대각선이 한 점(중앙)에서 교차 완료되었을 때") {
+        // 가로 1줄(0,1,2) + 세로 1줄(0,3,6) + 대각선 2줄(0,4,8 / 2,4,6)
+        // 0,1,2,3,4,6,8 을 완료하면 4개 라인이 동시에 성립한다
+        val items = createItems(3)
+        items.complete(memberId, 0, 1, 2, 3, 4, 6, 8)
+        val bingoMap = BingoMap(memberId, 3, items)
+
+        When("총 빙고 개수를 계산하면") {
+            val count = bingoMap.calculateTotalBingoCount()
+
+            Then("교차된 4개 라인이 인식된다") {
+                count shouldBe 4
+            }
+        }
+    }
+
+    Given("3x3 빙고맵의 모든 아이템이 완료되었을 때") {
+        val items = createItems(3)
+        items.complete(memberId, 0, 1, 2, 3, 4, 5, 6, 7, 8)
+        val bingoMap = BingoMap(memberId, 3, items)
+
+        When("총 빙고 개수를 계산하면") {
+            val count = bingoMap.calculateTotalBingoCount()
+
+            Then("가로3 + 세로3 + 대각선2 = 8개 라인이 모두 인식된다") {
+                count shouldBe 8
+            }
+        }
+    }
+
+    Given("4x4 빙고맵에서 가로 한 줄(4,5,6,7)이 완료되었을 때") {
+        val items = createItems(4)
+        items.complete(memberId, 4, 5, 6, 7)
+        val bingoMap = BingoMap(memberId, 4, items)
+
+        When("총 빙고 개수를 계산하면") {
+            val count = bingoMap.calculateTotalBingoCount()
+
+            Then("가로 빙고 1개가 인식된다") {
+                count shouldBe 1
+            }
+        }
+
+        When("가로 방향 빙고 인덱스를 조회하면") {
+            val indexes = bingoMap.getBingoIndexes(Direction.HORIZONTAL)
+
+            Then("두 번째 가로 줄(1번 인덱스)만 반환된다") {
+                indexes shouldBe listOf(1)
+            }
+        }
+    }
+
+    Given("4x4 빙고맵에서 좌상-우하 대각선(0,5,10,15)이 완료되었을 때") {
+        val items = createItems(4)
+        items.complete(memberId, 0, 5, 10, 15)
+        val bingoMap = BingoMap(memberId, 4, items)
+
+        When("대각선 방향 빙고 인덱스를 조회하면") {
+            val indexes = bingoMap.getBingoIndexes(Direction.DIAGONAL)
+
+            Then("첫 번째 대각선(0번 인덱스)만 반환된다") {
+                indexes shouldBe listOf(0)
+            }
+        }
+    }
+
+    Given("4x4 빙고맵에서 우상-좌하 대각선(3,6,9,12)이 완료되었을 때") {
+        val items = createItems(4)
+        items.complete(memberId, 3, 6, 9, 12)
+        val bingoMap = BingoMap(memberId, 4, items)
+
+        When("대각선 방향 빙고 인덱스를 조회하면") {
+            val indexes = bingoMap.getBingoIndexes(Direction.DIAGONAL)
+
+            Then("두 번째 대각선(1번 인덱스)만 반환된다") {
+                indexes shouldBe listOf(1)
+            }
+        }
+    }
+
+    Given("5x5 빙고맵에서 좌상-우하 대각선(0,6,12,18,24)이 완료되었을 때") {
+        val items = createItems(5)
+        items.complete(memberId, 0, 6, 12, 18, 24)
+        val bingoMap = BingoMap(memberId, 5, items)
+
+        When("총 빙고 개수를 계산하면") {
+            val count = bingoMap.calculateTotalBingoCount()
+
+            Then("대각선 빙고 1개가 인식된다") {
+                count shouldBe 1
+            }
+        }
+
+        When("대각선 방향 빙고 인덱스를 조회하면") {
+            val indexes = bingoMap.getBingoIndexes(Direction.DIAGONAL)
+
+            Then("첫 번째 대각선(0번 인덱스)만 반환된다") {
+                indexes shouldBe listOf(0)
+            }
+        }
+    }
+
+    Given("5x5 빙고맵에서 세로 두 줄(0열, 4열)이 완료되었을 때") {
+        val items = createItems(5)
+        // 0열: 0,5,10,15,20 / 4열: 4,9,14,19,24
+        items.complete(memberId, 0, 5, 10, 15, 20, 4, 9, 14, 19, 24)
+        val bingoMap = BingoMap(memberId, 5, items)
+
+        When("세로 방향 빙고 인덱스를 조회하면") {
+            val indexes = bingoMap.getBingoIndexes(Direction.VERTICAL)
+
+            Then("0번, 4번 인덱스가 반환된다") {
+                indexes shouldContainExactlyInAnyOrder listOf(0, 4)
+            }
+        }
+    }
+
+    Given("BingoMap 라인 구성") {
+        val items = createItems(3)
+        val bingoMap = BingoMap(memberId, 3, items)
+
+        When("방향별 라인을 조회하면") {
+            val horizontal = bingoMap.getBingoLines(Direction.HORIZONTAL)
+            val vertical = bingoMap.getBingoLines(Direction.VERTICAL)
+            val diagonal = bingoMap.getBingoLines(Direction.DIAGONAL)
+
+            Then("가로/세로는 사이즈만큼, 대각선은 2개가 생성된다") {
+                horizontal shouldHaveSize 3
+                vertical shouldHaveSize 3
+                diagonal shouldHaveSize 2
+            }
+        }
+    }
+
+    Given("같은 아이템들에 서로 다른 두 멤버가 완료를 기록했을 때") {
+        val otherMemberId = 2L
+        val items = createItems(3)
+        // memberId 는 가로 첫 줄(0,1,2), otherMemberId 는 세로 첫 줄(0,3,6) 완료
+        items.complete(memberId, 0, 1, 2)
+        items.complete(otherMemberId, 0, 3, 6)
+
+        When("memberId 기준 빙고맵을 계산하면") {
+            val count = BingoMap(memberId, 3, items).calculateTotalBingoCount()
+
+            Then("memberId 가 완료한 가로 1줄만 인식된다") {
+                count shouldBe 1
+            }
+        }
+
+        When("otherMemberId 기준 빙고맵을 계산하면") {
+            val count = BingoMap(otherMemberId, 3, items).calculateTotalBingoCount()
+
+            Then("otherMemberId 가 완료한 세로 1줄만 인식된다") {
+                count shouldBe 1
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoMemberTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoMemberTest.kt
@@ -1,0 +1,38 @@
+package com.beside.groubing.domain.bingo.domain
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class BingoMemberTest : BehaviorSpec({
+
+    Given("BingoMember.create") {
+        When("memberType 을 지정하지 않고 생성하면") {
+            val member = BingoMember.create(memberId = 1L)
+
+            Then("PARTICIPANT 타입으로 활성 상태로 생성된다.") {
+                member.bingoMemberType shouldBe BingoMemberType.PARTICIPANT
+                member.isLeader() shouldBe false
+                member.active shouldBe true
+            }
+        }
+
+        When("LEADER 타입으로 생성하면") {
+            val member = BingoMember.create(memberId = 1L, bingoMemberType = BingoMemberType.LEADER)
+
+            Then("isLeader 가 true 다.") {
+                member.isLeader() shouldBe true
+            }
+        }
+    }
+
+    Given("inactive") {
+        When("활성 멤버를 비활성화하면") {
+            val member = BingoMember.create(memberId = 1L)
+            member.inactive()
+
+            Then("active 가 false 가 된다.") {
+                member.active shouldBe false
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoMembersTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoMembersTest.kt
@@ -1,0 +1,148 @@
+package com.beside.groubing.domain.bingo.domain
+
+import com.beside.groubing.domain.bingo.exception.BingoIllegalStateException
+import com.beside.groubing.domain.bingo.exception.BingoInputException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+class BingoMembersTest : BehaviorSpec({
+
+    val leaderId = 1L
+    val participantId = 2L
+    val bingoBoardId = 10L
+
+    fun membersOf(leader: Long = leaderId, participants: List<Long> = listOf(participantId)): BingoMembers {
+        val list = mutableListOf(
+            BingoMember.of(1L, leader, BingoMemberType.LEADER, active = true)
+        )
+        participants.forEachIndexed { index, memberId ->
+            list.add(BingoMember.of((index + 2).toLong(), memberId, BingoMemberType.PARTICIPANT, active = true))
+        }
+        return BingoMembers.of(list)
+    }
+
+    Given("BingoMembers.ofLeader") {
+        When("리더만으로 생성하면") {
+            val members = BingoMembers.ofLeader(leaderId)
+
+            Then("리더 1명이 LEADER 타입으로 등록된다.") {
+                members.memberIds() shouldBe listOf(leaderId)
+                members.isLeaderOf(leaderId) shouldBe true
+            }
+        }
+    }
+
+    Given("isLeaderOf") {
+        val members = membersOf()
+
+        When("리더 아이디로 확인하면") {
+            Then("true 를 반환한다.") {
+                members.isLeaderOf(leaderId) shouldBe true
+            }
+        }
+
+        When("참여자 아이디로 확인하면") {
+            Then("false 를 반환한다.") {
+                members.isLeaderOf(participantId) shouldBe false
+            }
+        }
+    }
+
+    Given("findOf") {
+        val members = membersOf()
+
+        When("포함된 회원으로 조회하면") {
+            Then("해당 멤버를 반환한다.") {
+                members.findOf(participantId, bingoBoardId).memberId shouldBe participantId
+            }
+        }
+
+        When("포함되지 않은 회원으로 조회하면") {
+            Then("BingoInputException 이 발생한다.") {
+                shouldThrow<BingoInputException> {
+                    members.findOf(999L, bingoBoardId)
+                }
+            }
+        }
+    }
+
+    Given("validateLeaderOf") {
+        val members = membersOf()
+
+        When("리더가 검증하면") {
+            Then("예외가 발생하지 않는다.") {
+                members.validateLeaderOf(leaderId, bingoBoardId)
+            }
+        }
+
+        When("참여자가 검증하면") {
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    members.validateLeaderOf(participantId, bingoBoardId)
+                }.message shouldBe "해당 빙고를 수정할 권한이 없습니다."
+            }
+        }
+
+        When("포함되지 않은 회원이 검증하면") {
+            Then("BingoInputException 이 발생한다.") {
+                shouldThrow<BingoInputException> {
+                    members.validateLeaderOf(999L, bingoBoardId)
+                }
+            }
+        }
+    }
+
+    Given("addNewMembers") {
+        When("새 회원들을 추가하면") {
+            val members = membersOf(participants = emptyList())
+            members.addNewMembers(listOf(2L, 3L))
+
+            Then("PARTICIPANT 로 추가되어 전체 회원 목록에 반영된다.") {
+                members.memberIds() shouldContainExactlyInAnyOrder listOf(leaderId, 2L, 3L)
+                members.isLeaderOf(2L) shouldBe false
+            }
+        }
+    }
+
+    Given("otherMemberIdsOf / otherActiveMemberIdsOf") {
+        When("특정 회원을 제외하고 조회하면") {
+            val members = membersOf(participants = listOf(2L, 3L))
+
+            Then("나머지 회원 아이디를 반환한다.") {
+                members.otherMemberIdsOf(leaderId) shouldContainExactlyInAnyOrder listOf(2L, 3L)
+            }
+        }
+
+        When("비활성 회원이 섞여 있고 활성 회원만 조회하면") {
+            val members = membersOf(participants = listOf(2L, 3L))
+            members.inactivateOf(2L, bingoBoardId)
+
+            Then("비활성 회원은 제외된다.") {
+                members.otherActiveMemberIdsOf(leaderId) shouldContainExactlyInAnyOrder listOf(3L)
+            }
+        }
+    }
+
+    Given("inactivateOf") {
+        When("포함된 회원을 비활성화하면") {
+            val members = membersOf()
+            members.inactivateOf(participantId, bingoBoardId)
+
+            Then("해당 회원이 활성 목록에서 제외된다.") {
+                members.otherActiveMemberIdsOf(leaderId).contains(participantId) shouldBe false
+            }
+        }
+
+        When("포함되지 않은 회원을 비활성화하면") {
+            val members = membersOf()
+
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    members.inactivateOf(999L, bingoBoardId)
+                }
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoPeriodTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoPeriodTest.kt
@@ -1,0 +1,119 @@
+package com.beside.groubing.domain.bingo.domain
+
+import com.beside.groubing.domain.bingo.exception.BingoInputException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+class BingoPeriodTest : BehaviorSpec({
+    val today = LocalDate.now()
+
+    Given("BingoPeriod.create 로 기간을 생성할 때") {
+        When("시작일이 오늘, 종료일이 미래이면") {
+            val period = BingoPeriod.create(today, today.plusDays(7))
+
+            Then("정상적으로 생성된다") {
+                period.since shouldBe today
+                period.until shouldBe today.plusDays(7)
+            }
+        }
+
+        When("시작일과 종료일이 모두 오늘이면(경계값)") {
+            val period = BingoPeriod.create(today, today)
+
+            Then("정상적으로 생성된다") {
+                period.since shouldBe today
+                period.until shouldBe today
+            }
+        }
+
+        When("시작일이 과거이지만 종료일이 미래이면") {
+            val period = BingoPeriod.create(today.minusDays(3), today.plusDays(3))
+
+            Then("정상적으로 생성된다 (시작일은 과거여도 허용)") {
+                period.since shouldBe today.minusDays(3)
+                period.until shouldBe today.plusDays(3)
+            }
+        }
+
+        When("종료일이 과거이면") {
+            Then("BingoInputException 이 발생한다 - 종료일은 과거일 수 없음") {
+                shouldThrow<BingoInputException> {
+                    BingoPeriod.create(today.minusDays(10), today.minusDays(1))
+                }.message shouldBe "빙고 종료일은 현재 과거일 수 없습니다."
+            }
+        }
+
+        When("종료일이 시작일보다 과거이면(기간 역전)") {
+            Then("BingoInputException 이 발생한다 - 종료일은 시작일보다 과거일 수 없음") {
+                shouldThrow<BingoInputException> {
+                    BingoPeriod.create(today.plusDays(10), today.plusDays(5))
+                }.message shouldBe "빙고 종료일은 시작일보다 과거일 수 없습니다."
+            }
+        }
+    }
+
+    Given("BingoPeriod.of 는 검증 없이 재구성한다") {
+        When("종료일이 시작일보다 과거인 값으로 of 를 호출하면") {
+            val period = BingoPeriod.of(today.plusDays(10), today.plusDays(5))
+
+            Then("예외 없이 그대로 생성된다") {
+                period.since shouldBe today.plusDays(10)
+                period.until shouldBe today.plusDays(5)
+            }
+        }
+    }
+
+    Given("isExpired 판정") {
+        When("종료일이 미래이면") {
+            val period = BingoPeriod.of(today, today.plusDays(1))
+
+            Then("만료되지 않았다") {
+                period.isExpired() shouldBe false
+            }
+        }
+
+        When("종료일이 오늘이면") {
+            val period = BingoPeriod.of(today, today)
+
+            Then("아직 만료되지 않았다 (오늘 이후부터 만료)") {
+                period.isExpired() shouldBe false
+            }
+        }
+
+        When("종료일이 과거이면") {
+            val period = BingoPeriod.of(today.minusDays(5), today.minusDays(1))
+
+            Then("만료되었다") {
+                period.isExpired() shouldBe true
+            }
+        }
+    }
+
+    Given("calculateLeftDays 계산") {
+        When("종료일이 7일 뒤이면") {
+            val period = BingoPeriod.of(today, today.plusDays(7))
+
+            Then("남은 일수는 7일이다") {
+                period.calculateLeftDays() shouldBe 7L
+            }
+        }
+
+        When("종료일이 오늘이면") {
+            val period = BingoPeriod.of(today, today)
+
+            Then("남은 일수는 0일이다") {
+                period.calculateLeftDays() shouldBe 0L
+            }
+        }
+
+        When("종료일이 과거(2일 전)이면") {
+            val period = BingoPeriod.of(today.minusDays(5), today.minusDays(2))
+
+            Then("남은 일수는 음수(-2일)이다") {
+                period.calculateLeftDays() shouldBe -2L
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoSizeTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoSizeTest.kt
@@ -1,0 +1,90 @@
+package com.beside.groubing.domain.bingo.domain
+
+import com.beside.groubing.domain.bingo.exception.BingoInputException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class BingoSizeTest : BehaviorSpec({
+
+    Given("BingoSize.cache 로 빙고 사이즈를 생성할 때") {
+        When("최소값 3으로 생성하면") {
+            val bingoSize = BingoSize.cache(3)
+
+            Then("size 가 3인 객체가 생성된다") {
+                bingoSize.size shouldBe 3
+            }
+        }
+
+        When("최대값 10으로 생성하면") {
+            val bingoSize = BingoSize.cache(10)
+
+            Then("size 가 10인 객체가 생성된다") {
+                bingoSize.size shouldBe 10
+            }
+        }
+
+        When("중간값 5로 생성하면") {
+            val bingoSize = BingoSize.cache(5)
+
+            Then("size 가 5인 객체가 생성된다") {
+                bingoSize.size shouldBe 5
+            }
+        }
+
+        When("같은 사이즈를 두 번 생성하면") {
+            val first = BingoSize.cache(4)
+            val second = BingoSize.cache(4)
+
+            Then("캐시된 동일 인스턴스가 반환된다") {
+                (first === second) shouldBe true
+            }
+        }
+
+        When("최소값 미만인 2로 생성하면") {
+            Then("BingoInputException 이 발생한다") {
+                shouldThrow<BingoInputException> {
+                    BingoSize.cache(2)
+                }.message shouldBe "빙고 사이즈가 잘못 되었습니다."
+            }
+        }
+
+        When("최대값 초과인 11로 생성하면") {
+            Then("BingoInputException 이 발생한다") {
+                shouldThrow<BingoInputException> {
+                    BingoSize.cache(11)
+                }.message shouldBe "빙고 사이즈가 잘못 되었습니다."
+            }
+        }
+
+        When("0으로 생성하면") {
+            Then("BingoInputException 이 발생한다") {
+                shouldThrow<BingoInputException> {
+                    BingoSize.cache(0)
+                }
+            }
+        }
+
+        When("음수로 생성하면") {
+            Then("BingoInputException 이 발생한다") {
+                shouldThrow<BingoInputException> {
+                    BingoSize.cache(-1)
+                }
+            }
+        }
+    }
+
+    Given("getMaxGoal 파생 속성") {
+        When("size 가 3이면") {
+            Then("최대 목표는 (3*2)+2 = 8 이다") {
+                BingoSize.cache(3).getMaxGoal() shouldBe 8
+            }
+        }
+
+        When("size 가 10이면") {
+            Then("최대 목표는 (10*2)+2 = 22 이다") {
+                BingoSize.cache(10).getMaxGoal() shouldBe 22
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/fixture/BingoBoardFixture.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/fixture/BingoBoardFixture.kt
@@ -1,0 +1,127 @@
+package com.beside.groubing.domain.bingo.fixture
+
+import com.beside.groubing.domain.bingo.domain.BingoBoard
+import com.beside.groubing.domain.bingo.domain.BingoBoardType
+import com.beside.groubing.domain.bingo.domain.BingoColor
+import com.beside.groubing.domain.bingo.domain.BingoGoal
+import com.beside.groubing.domain.bingo.domain.BingoItem
+import com.beside.groubing.domain.bingo.domain.BingoItems
+import com.beside.groubing.domain.bingo.domain.BingoMember
+import com.beside.groubing.domain.bingo.domain.BingoMemberType
+import com.beside.groubing.domain.bingo.domain.BingoMembers
+import com.beside.groubing.domain.bingo.domain.BingoPeriod
+import com.beside.groubing.domain.bingo.domain.BingoSize
+import java.time.LocalDate
+
+/**
+ * 테스트에서 BingoBoard 애그리거트를 결정적(deterministic)으로 조립하기 위한 Fixture.
+ *
+ * 프로덕션 [BingoBoard.create] 는 아이템 order/이미지/색상을 랜덤으로 섞기 때문에
+ * 빙고 라인 완성 같은 위치 의존 테스트에는 부적합하다.
+ * 이 Fixture 는 [BingoBoard.of] 와 [BingoItem.of] 를 사용해 itemOrder 가 1..N*N 으로
+ * 고정되고, 모든 아이템에 title 이 채워진(=isAllUpdated) 보드를 만든다.
+ */
+object BingoBoardFixture {
+
+    const val LEADER_ID = 1L
+    const val PARTICIPANT_ID = 2L
+
+    /**
+     * itemOrder 가 1..(size*size) 로 채워진, 모든 아이템에 title 이 있는 BingoItems.
+     * 인덱스 i 의 아이템 id 는 (i+1), itemOrder 도 (i+1) 로 1:1 매핑된다.
+     *
+     * @param updated false 면 일부(첫 아이템)의 title 을 null 로 두어 isAllUpdated=false 를 만든다.
+     */
+    fun bingoItems(size: Int = 3, updated: Boolean = true): BingoItems {
+        val total = size * size
+        val items = (1..total).map { order ->
+            BingoItem.of(
+                id = order.toLong(),
+                title = if (updated) "item-$order" else if (order == 1) null else "item-$order",
+                subTitle = null,
+                imageUrl = "g",
+                itemOrder = order,
+                colorCode = "#2787C9",
+                completeMembers = mutableSetOf()
+            )
+        }
+        return BingoItems.of(items)
+    }
+
+    fun bingoMembers(
+        leaderId: Long = LEADER_ID,
+        participantIds: List<Long> = emptyList()
+    ): BingoMembers {
+        val members = mutableListOf(
+            BingoMember.of(id = 1L, memberId = leaderId, bingoMemberType = BingoMemberType.LEADER, active = true)
+        )
+        participantIds.forEachIndexed { index, memberId ->
+            members.add(
+                BingoMember.of(
+                    id = (index + 2).toLong(),
+                    memberId = memberId,
+                    bingoMemberType = BingoMemberType.PARTICIPANT,
+                    active = true
+                )
+            )
+        }
+        return BingoMembers.of(members)
+    }
+
+    /**
+     * 시작된(임시빙고가 아닌) 그룹 빙고 보드. period 가 세팅되어 있고 모든 아이템에 title 이 있어 isStarted=true.
+     */
+    fun startedBoard(
+        id: Long = 1L,
+        size: Int = 3,
+        goal: Int = 1,
+        leaderId: Long = LEADER_ID,
+        participantIds: List<Long> = emptyList(),
+        until: LocalDate = LocalDate.now().plusDays(7),
+        open: Boolean = true
+    ): BingoBoard {
+        val bingoSize = BingoSize.cache(size)
+        return BingoBoard.of(
+            id = id,
+            title = "그루빙 빙고",
+            boardType = BingoBoardType.GROUP,
+            bingoColor = BingoColor.BLUE,
+            open = open,
+            memo = null,
+            active = true,
+            bingoSize = bingoSize,
+            bingoGoal = BingoGoal.create(goal, bingoSize),
+            period = BingoPeriod.of(LocalDate.now(), until),
+            bingoMembers = bingoMembers(leaderId, participantIds),
+            bingoItems = bingoItems(size, updated = true)
+        )
+    }
+
+    /**
+     * 임시(temporary) 빙고 보드. period 가 null 이라 isStarted=false → shuffle 가능, complete/cancel 불가.
+     */
+    fun temporaryBoard(
+        id: Long = 1L,
+        size: Int = 3,
+        goal: Int = 1,
+        leaderId: Long = LEADER_ID,
+        participantIds: List<Long> = emptyList(),
+        allUpdated: Boolean = false
+    ): BingoBoard {
+        val bingoSize = BingoSize.cache(size)
+        return BingoBoard.of(
+            id = id,
+            title = "임시 빙고",
+            boardType = BingoBoardType.GROUP,
+            bingoColor = BingoColor.BLUE,
+            open = true,
+            memo = null,
+            active = true,
+            bingoSize = bingoSize,
+            bingoGoal = BingoGoal.create(goal, bingoSize),
+            period = null,
+            bingoMembers = bingoMembers(leaderId, participantIds),
+            bingoItems = bingoItems(size, updated = allUpdated)
+        )
+    }
+}

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/blockedmember/domain/BlockMemberValidatorTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/blockedmember/domain/BlockMemberValidatorTest.kt
@@ -1,0 +1,39 @@
+package com.beside.groubing.domain.blockedmember.domain
+
+import com.beside.groubing.domain.blockedmember.domain.port.BlockedMemberRepository
+import com.beside.groubing.domain.blockedmember.exception.BlockedMemberInputException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class BlockMemberValidatorTest : BehaviorSpec({
+    val blockedMemberRepository = mockk<BlockedMemberRepository>()
+    val validator = BlockMemberValidator(blockedMemberRepository)
+
+    val requesterId = 1L
+    val targetMemberId = 2L
+
+    Given("아직 차단하지 않은 회원일 때") {
+        every { blockedMemberRepository.exists(requesterId, targetMemberId) } returns false
+
+        When("validate 호출") {
+            Then("예외가 발생하지 않는다") {
+                validator.validate(requesterId, targetMemberId)
+            }
+        }
+    }
+
+    Given("이미 차단한 회원일 때") {
+        every { blockedMemberRepository.exists(requesterId, targetMemberId) } returns true
+
+        When("validate 호출") {
+            Then("BlockedMemberInputException 이 발생한다") {
+                shouldThrow<BlockedMemberInputException> {
+                    validator.validate(requesterId, targetMemberId)
+                }.message shouldBe "이미 차단한 유저입니다."
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/member/domain/NicknameUniquenessValidatorTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/member/domain/NicknameUniquenessValidatorTest.kt
@@ -1,0 +1,38 @@
+package com.beside.groubing.domain.member.domain
+
+import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
+import com.beside.groubing.domain.member.exception.MemberInputException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class NicknameUniquenessValidatorTest : BehaviorSpec({
+    val memberQueryRepository = mockk<MemberQueryRepository>()
+    val validator = NicknameUniquenessValidator(memberQueryRepository)
+
+    val nickname = "그루빙"
+
+    Given("닉네임이 중복되지 않을 때") {
+        every { memberQueryRepository.existsByNickname(nickname) } returns false
+
+        When("validate 호출") {
+            Then("예외가 발생하지 않는다") {
+                validator.validate(nickname)
+            }
+        }
+    }
+
+    Given("이미 사용 중인 닉네임일 때") {
+        every { memberQueryRepository.existsByNickname(nickname) } returns true
+
+        When("validate 호출") {
+            Then("MemberInputException 이 발생한다") {
+                shouldThrow<MemberInputException> {
+                    validator.validate(nickname)
+                }.message shouldBe "이미 사용 중인 닉네임 입니다."
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 배경
순수 도메인 단위 테스트가 5개뿐(Friend 위주)이라, 가장 단위테스트 가치가 높은 핵심 도메인 로직을 보강한다. (API 31개·DAO 7개는 이미 잘 덮여 있음)

## 추가 내용 (신규 14 + 전환·확장 2)
- **Bingo 애그리거트**: `BingoBoardTest`(완료/취소/셔플/`updateBase`·`MembersPeriod`·`Memo`·`Open`/`delete`/권한·열람 검증·도메인 이벤트), `BingoItemsTest`·`BingoItemTest`·`BingoMembersTest`·`BingoMemberTest`·`BingoCompleteMemberTest`, `BingoBoardFixture`(결정적 조립)
- **Bingo 알고리즘·VO**: `BingoMapTest` raw JUnit → **Kotest 전환** + 3x3/4x4/5x5·멤버별 라인 확장, `BingoSizeTest`·`BingoGoalTest`·`BingoPeriodTest`(불변식 경계·예외)
- **Validator**: `SignUpValidatorTest`(loginId null 스킵 분기 포함)·`NicknameUniquenessValidatorTest`·`BingoBoardMembersValidatorTest`·`BlockMemberValidatorTest`·`PasswordVerifierTest`

## 검증
- 전부 Kotest `BehaviorSpec`, 기존 컨벤션 일치.
- **프로덕션 코드 변경 없음** — 순수 테스트 추가.
- `./gradlew test` 전체 BUILD SUCCESSFUL (domain-core 166 passed + 타 모듈 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)