### PR TITLE
build: JaCoCo 코드 커버리지 측정 설정 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
+import org.gradle.testing.jacoco.tasks.JacocoReport
 
 plugins {
     kotlin("jvm") version "1.9.25"
@@ -27,6 +29,7 @@ subprojects {
     apply(plugin = "kotlin")
     apply(plugin = "kotlin-spring")
     apply(plugin = "kotlin-kapt")
+    apply(plugin = "jacoco")
 
     java {
         toolchain {
@@ -59,6 +62,34 @@ subprojects {
 
     tasks.withType<Test> {
         useJUnitPlatform()
+        finalizedBy(tasks.withType<JacocoReport>())
+    }
+
+    extensions.configure<JacocoPluginExtension> {
+        toolVersion = "0.8.12"
+    }
+
+    tasks.withType<JacocoReport> {
+        dependsOn(tasks.withType<Test>())
+        reports {
+            html.required.set(true)
+            xml.required.set(true)
+        }
+        // 생성·무로직 코드는 커버리지 측정에서 제외
+        classDirectories.setFrom(
+            files(classDirectories.files.map {
+                fileTree(it) {
+                    exclude(
+                        "**/Q*.class",        // QueryDSL kapt 생성물
+                        "**/*Application*",   // 부트 진입점
+                        "**/config/**",
+                        "**/*Config*",
+                        "**/entity/**",       // JPA 엔티티
+                        "**/payload/**"       // 요청/응답 DTO
+                    )
+                }
+            })
+        )
     }
 }
 


### PR DESCRIPTION
## 내용
리프 모듈 공통(`subprojects`)에 `jacoco` 플러그인 적용. `test` 후 `jacocoTestReport`(HTML+XML) 자동 생성.

- `toolVersion = "0.8.12"` (JDK 21 호환)
- 생성·무로직 코드 측정 제외: QueryDSL `Q*` / `*Application` / `config` / `entity` / `payload`
- **임계값 게이트는 미포함** — 현재 서비스·어댑터 레이어가 비어 처음부터 강제하면 빌드가 깨짐. 베이스라인 측정 후 점진 도입.

## 사용
```bash
./gradlew test jacocoTestReport
# 모듈별: <module>/build/reports/jacoco/test/html/index.html
```

## 측정된 베이스라인 (PR #26 도메인 테스트 포함 기준)
| 모듈 | 라인 | 분기 |
|---|---|---|
| gb-domain-core | 57.6% | 79.7% |
| gb-boot-web | 70.4% | 55.6% |
| gb-db-core | 51.9% | 29.0% |
| gb-id-obfuscator | 100% | 100% |

→ 도메인 분기 79.7%로 비즈니스 결정 로직은 양호. gb-db-core(어댑터 deep-sync)가 최약점.

🤖 Generated with [Claude Code](https://claude.com/claude-code)