### PR TITLE
feat: 빙고 리더 검증 쿼리/검증자 추가 (operation 영속화 Slice 0)

### DIFF
--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoLeaderValidator.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoLeaderValidator.kt
@@ -1,0 +1,16 @@
+package com.beside.groubing.domain.bingo.domain
+
+import com.beside.groubing.domain.bingo.domain.port.BingoBoardQueryRepository
+import com.beside.groubing.domain.bingo.exception.BingoIllegalStateException
+import org.springframework.stereotype.Component
+
+@Component
+class BingoLeaderValidator(
+    private val bingoBoardQueryRepository: BingoBoardQueryRepository
+) {
+    fun validate(bingoBoardId: Long, memberId: Long) {
+        if (!bingoBoardQueryRepository.isLeaderOf(bingoBoardId, memberId)) {
+            throw BingoIllegalStateException("해당 빙고를 수정할 권한이 없습니다.")
+        }
+    }
+}

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardQueryRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardQueryRepository.kt
@@ -8,4 +8,6 @@ interface BingoBoardQueryRepository {
     fun findAllOf(memberId: Long): List<BingoBoard>
 
     fun findAllIdsOf(memberId: Long): List<Long>
+
+    fun isLeaderOf(bingoBoardId: Long, memberId: Long): Boolean
 }

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoLeaderValidatorTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoLeaderValidatorTest.kt
@@ -1,0 +1,42 @@
+package com.beside.groubing.domain.bingo.domain
+
+import com.beside.groubing.domain.bingo.domain.port.BingoBoardQueryRepository
+import com.beside.groubing.domain.bingo.exception.BingoIllegalStateException
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class BingoLeaderValidatorTest : BehaviorSpec({
+    val bingoBoardQueryRepository = mockk<BingoBoardQueryRepository>()
+    val validator = BingoLeaderValidator(bingoBoardQueryRepository)
+
+    val bingoBoardId = 2L
+    val memberId = 1L
+
+    Given("해당 회원이 빙고의 리더일 때") {
+        every { bingoBoardQueryRepository.isLeaderOf(bingoBoardId, memberId) } returns true
+
+        When("validate 호출") {
+            Then("예외가 발생하지 않는다") {
+                shouldNotThrowAny {
+                    validator.validate(bingoBoardId, memberId)
+                }
+            }
+        }
+    }
+
+    Given("해당 회원이 빙고의 리더가 아닐 때") {
+        every { bingoBoardQueryRepository.isLeaderOf(bingoBoardId, memberId) } returns false
+
+        When("validate 호출") {
+            Then("BingoIllegalStateException 이 발생한다") {
+                shouldThrow<BingoIllegalStateException> {
+                    validator.validate(bingoBoardId, memberId)
+                }.message shouldBe "해당 빙고를 수정할 권한이 없습니다."
+            }
+        }
+    }
+})

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/dao/BingoBoardListFindDao.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/dao/BingoBoardListFindDao.kt
@@ -1,5 +1,6 @@
 package com.beside.groubing.domain.bingo.dao
 
+import com.beside.groubing.domain.bingo.domain.BingoMemberType
 import com.beside.groubing.domain.bingo.entity.BingoBoardEntity
 import com.beside.groubing.domain.bingo.entity.QBingoBoardEntity.bingoBoardEntity
 import com.beside.groubing.domain.bingo.entity.QBingoMemberEntity.bingoMemberEntity
@@ -27,6 +28,20 @@ class BingoBoardListFindDao(
             .innerJoin(bingoBoardEntity.bingoMembers, bingoMemberEntity)
             .where(activePredicate(memberId))
             .fetch()
+    }
+
+    fun isLeaderOf(bingoBoardId: Long, memberId: Long): Boolean {
+        return queryFactory.selectOne()
+            .from(bingoBoardEntity)
+            .innerJoin(bingoBoardEntity.bingoMembers, bingoMemberEntity)
+            .where(
+                bingoBoardEntity.id.eq(bingoBoardId)
+                    .and(bingoBoardEntity.active.isTrue)
+                    .and(bingoMemberEntity.active.isTrue)
+                    .and(bingoMemberEntity.memberId.eq(memberId))
+                    .and(bingoMemberEntity.bingoMemberType.eq(BingoMemberType.LEADER))
+            )
+            .fetchFirst() != null
     }
 
     private fun activePredicate(memberId: Long) = BooleanBuilder()

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
@@ -54,6 +54,9 @@ class BingoBoardRepositoryAdapter(
     override fun findAllIdsOf(memberId: Long): List<Long> =
         bingoBoardListFindDao.findAllIdsOf(memberId)
 
+    override fun isLeaderOf(bingoBoardId: Long, memberId: Long): Boolean =
+        bingoBoardListFindDao.isLeaderOf(bingoBoardId, memberId)
+
     private fun findActiveEntityById(id: Long): BingoBoardEntity {
         return bingoBoardJpaRepository.findByIdAndActiveIsTrue(id)
             .orElseThrow { BingoInputException("존재하지 않는 BingoBoard Id입니다. : $id") }

--- a/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/bingo/dao/BingoBoardListFindDaoTest.kt
+++ b/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/bingo/dao/BingoBoardListFindDaoTest.kt
@@ -8,6 +8,8 @@ import com.beside.groubing.domain.bingo.entity.BingoBoardEntity
 import com.beside.groubing.domain.bingo.repository.BingoBoardJpaRepository
 import com.beside.groubing.persistence.PersistenceTest
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import org.springframework.context.annotation.Import
@@ -19,14 +21,17 @@ class BingoBoardListFindDaoTest(
 
     private val bingoBoardJpaRepository: BingoBoardJpaRepository
 ) : DescribeSpec({
+    var englishStudyBoardId = 0L
+
     beforeTest {
-        bingoBoardJpaRepository.saveAll(
+        val saved = bingoBoardJpaRepository.saveAll(
             listOf(
                 BingoBoardEntity.from(aEnglishStudyBingoBoard()),
                 BingoBoardEntity.from(aHealthBingoBoard()),
                 BingoBoardEntity.from(aGameBingoBoard())
             )
         )
+        englishStudyBoardId = saved.first().id
     }
 
     listOf(
@@ -37,6 +42,24 @@ class BingoBoardListFindDaoTest(
 
             result.shouldNotBeEmpty()
             result.size shouldBe expectedSize
+        }
+    }
+
+    describe("isLeaderOf") {
+        it("리더이면 true 를 반환한다") {
+            bingoBoardListFindDao.isLeaderOf(englishStudyBoardId, memberId = 1L).shouldBeTrue()
+        }
+
+        it("참여자이면 false 를 반환한다") {
+            bingoBoardListFindDao.isLeaderOf(englishStudyBoardId, memberId = 3L).shouldBeFalse()
+        }
+
+        it("멤버가 아니면 false 를 반환한다") {
+            bingoBoardListFindDao.isLeaderOf(englishStudyBoardId, memberId = 99L).shouldBeFalse()
+        }
+
+        it("존재하지 않는 빙고보드이면 false 를 반환한다") {
+            bingoBoardListFindDao.isLeaderOf(bingoBoardId = 999L, memberId = 1L).shouldBeFalse()
         }
     }
 })


### PR DESCRIPTION
## 개요
빙고보드 영속화를 **스냅샷 reconcile → 의도별 operation 기반**으로 전환하는 리팩토링의 **Slice 0 (공통 선행 인프라)**.
operation 기반 슬라이스들은 애그리거트를 통째로 로드하지 않으므로, 기존에 로드된 애그리거트에서 하던 **리더 검증**을 쿼리 + 검증자로 분리한다. **행위 변화 없는 순수 추가**.

> 플랜: `docs/plan/202606/bingo-operation-based-persistence.plan.md` → Slice 0

## 변경 사항
| 파일 | 내용 |
|------|------|
| `BingoBoardQueryRepository` (port) | `isLeaderOf(bingoBoardId, memberId): Boolean` 추가 |
| `BingoBoardListFindDao` (dao) | QueryDSL `isLeaderOf` — board⨝member 조인, active 보드 + active 멤버 + `LEADER` 필터, `selectOne().fetchFirst() != null` |
| `BingoBoardRepositoryAdapter` | DAO 위임만 (로직 없음) |
| `BingoLeaderValidator` (신규 `@Component`) | 애그리거트 로드 없이 리더 검증. false면 `BingoIllegalStateException("해당 빙고를 수정할 권한이 없습니다.")` — 기존 `BingoMembers.validateLeaderOf`와 메시지 동일 |

## 테스트
- `BingoBoardListFindDaoTest` (`@PersistenceTest`/H2): 리더→true, 참여자→false, 비멤버→false, 미존재 보드→false
- `BingoLeaderValidatorTest` (BehaviorSpec/MockK): true→무예외, false→`BingoIllegalStateException`
- `./gradlew test --tests '*BingoBoardListFindDaoTest*' --tests '*BingoLeaderValidatorTest*'` → BUILD SUCCESSFUL

## 범위 / 비범위
- ✅ 순수 추가. 새 메서드 호출처는 아직 없음.
- ❌ `BingoMemberLeaveService`·`BingoBoard`·`BingoMembers.validateLeaderOf`·`update`/`sync*` 등 **기존 경로 미수정** — 재배선은 후속 operation 슬라이스(Slice 1+) 몫.

🤖 Generated with [Claude Code](https://claude.com/claude-code)