### PR TITLE
refactor: 빙고 기본정보 변경(PATCH /base)을 타깃 operation 영속화로 전환

### DIFF
--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardUpdateService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardUpdateService.kt
@@ -18,7 +18,7 @@ class BingoBoardUpdateService(
 ) {
     fun updateBase(bingoBoardId: Long, memberId: Long, command: BingoBoardBaseUpdateCommand): BingoBoard {
         val bingoBoard = bingoBoardQueryRepository.findOne(bingoBoardId)
-        command.update(bingoBoard, memberId)
+        bingoBoard.updateBase(memberId, command.title, command.goal, command.since, command.until)
         bingoBoardCommandRepository.updateBase(bingoBoardId, bingoBoard.title, bingoBoard.bingoGoal, bingoBoard.period!!)
         return bingoBoard
     }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardUpdateService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardUpdateService.kt
@@ -19,7 +19,8 @@ class BingoBoardUpdateService(
     fun updateBase(bingoBoardId: Long, memberId: Long, command: BingoBoardBaseUpdateCommand): BingoBoard {
         val bingoBoard = bingoBoardQueryRepository.findOne(bingoBoardId)
         command.update(bingoBoard, memberId)
-        return bingoBoardCommandRepository.update(bingoBoard)
+        bingoBoardCommandRepository.updateBase(bingoBoardId, bingoBoard.title, bingoBoard.bingoGoal, bingoBoard.period!!)
+        return bingoBoard
     }
 
     fun updateMembersPeriod(bingoBoardId: Long, memberId: Long, command: BingoBoardMembersPeriodUpdateCommand): BingoBoard {

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardCommandRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardCommandRepository.kt
@@ -1,11 +1,15 @@
 package com.beside.groubing.domain.bingo.domain.port
 
 import com.beside.groubing.domain.bingo.domain.BingoBoard
+import com.beside.groubing.domain.bingo.domain.BingoGoal
+import com.beside.groubing.domain.bingo.domain.BingoPeriod
 
 interface BingoBoardCommandRepository {
     fun save(bingoBoard: BingoBoard): BingoBoard
 
     fun update(bingoBoard: BingoBoard): BingoBoard
+
+    fun updateBase(bingoBoardId: Long, title: String, bingoGoal: BingoGoal, period: BingoPeriod)
 
     fun updateMemo(bingoBoardId: Long, memo: String?)
 

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/payload/command/BingoBoardBaseUpdateCommand.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/payload/command/BingoBoardBaseUpdateCommand.kt
@@ -1,6 +1,5 @@
 package com.beside.groubing.domain.bingo.payload.command
 
-import com.beside.groubing.domain.bingo.domain.BingoBoard
 import java.time.LocalDate
 
 class BingoBoardBaseUpdateCommand private constructor(
@@ -9,10 +8,6 @@ class BingoBoardBaseUpdateCommand private constructor(
     val since: LocalDate,
     val until: LocalDate
 ) {
-    fun update(bingoBoard: BingoBoard, memberId: Long) {
-        bingoBoard.updateBase(memberId, title, goal, since, until)
-    }
-
     companion object {
         fun of(
             title: String,

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardUpdateServiceTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardUpdateServiceTest.kt
@@ -4,12 +4,14 @@ import com.beside.groubing.aEnglishStudyBingoBoard
 import com.beside.groubing.domain.bingo.domain.BingoBoardMembersValidator
 import com.beside.groubing.domain.bingo.domain.port.BingoBoardCommandRepository
 import com.beside.groubing.domain.bingo.domain.port.BingoBoardQueryRepository
+import com.beside.groubing.domain.bingo.payload.command.BingoBoardBaseUpdateCommand
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import java.time.LocalDate
 
 class BingoBoardUpdateServiceTest : BehaviorSpec({
     val bingoBoardQueryRepository = mockk<BingoBoardQueryRepository>()
@@ -20,6 +22,36 @@ class BingoBoardUpdateServiceTest : BehaviorSpec({
         bingoBoardCommandRepository,
         bingoBoardMembersValidator
     )
+
+    given("리더(memberId=1)가 기본정보 변경을 요청할 때") {
+        val leaderId = 1L
+        val bingoBoardId = 2L
+        val newTitle = "새 제목"
+        val newGoal = 5
+        val since = LocalDate.now()
+        val until = LocalDate.now().plusDays(7)
+        val command = BingoBoardBaseUpdateCommand.of(newTitle, newGoal, since, until)
+        val bingoBoard = aEnglishStudyBingoBoard()
+
+        every { bingoBoardQueryRepository.findOne(bingoBoardId) } returns bingoBoard
+        justRun { bingoBoardCommandRepository.updateBase(bingoBoardId, any(), any(), any()) }
+
+        `when`("updateBase 를 호출하면") {
+            val result = bingoBoardUpdateService.updateBase(bingoBoardId, leaderId, command)
+
+            then("타깃 영속화 경로(updateBase)를 타고 스냅샷 update 는 호출하지 않는다") {
+                verify(exactly = 1) { bingoBoardCommandRepository.updateBase(bingoBoardId, newTitle, any(), any()) }
+                verify(exactly = 0) { bingoBoardCommandRepository.update(any()) }
+            }
+
+            then("기본정보가 변경된 도메인을 그대로 반환한다") {
+                result.title shouldBe newTitle
+                result.goal shouldBe newGoal
+                result.since shouldBe since
+                result.until shouldBe until
+            }
+        }
+    }
 
     given("리더(memberId=1)가 메모 변경을 요청할 때") {
         val leaderId = 1L

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoBoardEntity.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoBoardEntity.kt
@@ -3,8 +3,10 @@ package com.beside.groubing.domain.bingo.entity
 import com.beside.groubing.domain.bingo.domain.BingoBoard
 import com.beside.groubing.domain.bingo.domain.BingoBoardType
 import com.beside.groubing.domain.bingo.domain.BingoColor
+import com.beside.groubing.domain.bingo.domain.BingoGoal
 import com.beside.groubing.domain.bingo.domain.BingoItems
 import com.beside.groubing.domain.bingo.domain.BingoMembers
+import com.beside.groubing.domain.bingo.domain.BingoPeriod
 import com.beside.groubing.global.domain.jpa.BaseAggregateRoot
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
@@ -76,6 +78,12 @@ class BingoBoardEntity(
     @Embedded
     var period: BingoPeriodEmbeddable? = period
         private set
+
+    fun changeBase(title: String, bingoGoal: BingoGoal, period: BingoPeriod) {
+        this.title = title
+        this.bingoGoal = BingoGoalEmbeddable.from(bingoGoal)
+        this.period = BingoPeriodEmbeddable.from(period)
+    }
 
     fun changeMemo(memo: String?) {
         this.memo = memo

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
@@ -3,8 +3,10 @@ package com.beside.groubing.domain.bingo.repository
 import com.beside.groubing.domain.bingo.dao.BingoBoardListFindDao
 import com.beside.groubing.domain.bingo.domain.BingoBoard
 import com.beside.groubing.domain.bingo.domain.BingoCompleteMember
+import com.beside.groubing.domain.bingo.domain.BingoGoal
 import com.beside.groubing.domain.bingo.domain.BingoItems
 import com.beside.groubing.domain.bingo.domain.BingoMembers
+import com.beside.groubing.domain.bingo.domain.BingoPeriod
 import com.beside.groubing.domain.bingo.domain.port.BingoBoardCommandRepository
 import com.beside.groubing.domain.bingo.domain.port.BingoBoardQueryRepository
 import com.beside.groubing.domain.bingo.entity.BingoBoardEntity
@@ -33,6 +35,10 @@ class BingoBoardRepositoryAdapter(
         syncBingoItems(entity.bingoItems, bingoBoard.bingoItems)
         bingoBoard.pullEvents().forEach { entity.publishEvent(it) }
         return entity.toDomain()
+    }
+
+    override fun updateBase(bingoBoardId: Long, title: String, bingoGoal: BingoGoal, period: BingoPeriod) {
+        findActiveEntityById(bingoBoardId).changeBase(title, bingoGoal, period)
     }
 
     override fun updateMemo(bingoBoardId: Long, memo: String?) {

--- a/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapterTest.kt
+++ b/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapterTest.kt
@@ -2,6 +2,9 @@ package com.beside.groubing.domain.bingo.repository
 
 import com.beside.groubing.aEnglishStudyBingoBoard
 import com.beside.groubing.domain.bingo.dao.BingoBoardListFindDao
+import com.beside.groubing.domain.bingo.domain.BingoGoal
+import com.beside.groubing.domain.bingo.domain.BingoPeriod
+import com.beside.groubing.domain.bingo.domain.BingoSize
 import com.beside.groubing.domain.bingo.entity.BingoBoardEntity
 import com.beside.groubing.global.config.QuerydslConfig
 import com.beside.groubing.persistence.PersistenceTest
@@ -9,6 +12,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.context.annotation.Import
+import java.time.LocalDate
 
 @PersistenceTest
 @Import(BingoBoardRepositoryAdapter::class, BingoBoardListFindDao::class, QuerydslConfig::class)
@@ -17,6 +21,41 @@ class BingoBoardRepositoryAdapterTest(
     private val bingoBoardJpaRepository: BingoBoardJpaRepository,
     private val testEntityManager: TestEntityManager
 ) : DescribeSpec({
+
+    describe("updateBase") {
+        context("리더가 기본정보(제목/목표/기간)를 변경하면") {
+            it("해당 보드의 제목/목표/기간만 갱신되고 멤버/아이템은 그대로 유지된다") {
+                val saved = bingoBoardJpaRepository.save(BingoBoardEntity.from(aEnglishStudyBingoBoard()))
+                val savedId = saved.id
+                val originalMemberCount = saved.bingoMembers.size
+                val originalActiveCount = saved.bingoMembers.count { it.active }
+                val originalItemTitles = saved.bingoItems.sortedBy { it.id }.map { it.title }
+                val newTitle = "변경된 제목"
+                val newGoal = 5
+                val newSince = LocalDate.now().plusDays(1)
+                val newUntil = LocalDate.now().plusDays(10)
+
+                bingoBoardRepositoryAdapter.updateBase(
+                    savedId,
+                    newTitle,
+                    BingoGoal.create(newGoal, BingoSize.cache(3)),
+                    BingoPeriod.create(newSince, newUntil)
+                )
+                testEntityManager.flush()
+                testEntityManager.clear()
+
+                val reloaded = bingoBoardJpaRepository.findById(savedId).orElseThrow()
+                reloaded.title shouldBe newTitle
+                reloaded.bingoGoal.goal shouldBe newGoal
+                reloaded.period!!.since shouldBe newSince
+                reloaded.period!!.until shouldBe newUntil
+                reloaded.bingoMembers.size shouldBe originalMemberCount
+                reloaded.bingoMembers.count { it.active } shouldBe originalActiveCount
+                reloaded.bingoItems.size shouldBe originalItemTitles.size
+                reloaded.bingoItems.sortedBy { it.id }.map { it.title } shouldBe originalItemTitles
+            }
+        }
+    }
 
     describe("updateMemo") {
         context("리더가 메모를 변경하면") {


### PR DESCRIPTION
## 개요

빙고 operation 기반 영속화 전환의 **base 슬라이스** (Slice 1의 base 부분, memo=#29 / open=#31 에 이은 후속).

`PATCH /base`(기본정보: 제목·목표·기간 변경)가 보드를 통째 로드·diff 하던 스냅샷 `update(board)` 대신, 보드 행의 `title·bingoGoal·period` 만 갱신하는 **타깃 operation**(`updateBase`)을 타도록 전환한다.

## 변경 내용

**① operation 영속화 전환** (`6379675`)
- 포트 `BingoBoardCommandRepository.updateBase(id, title, bingoGoal, period)` 추가
- 엔티티 `BingoBoardEntity.changeBase(...)` mutator (`applyChanges`와 대칭, `.from()` 임베더블 매퍼 재사용)
- 어댑터 `updateBase` = `findActiveEntityById(id).changeBase(...)` 더티체킹 (멤버/아이템 자식 컬렉션 미변경)
- 서비스 `updateBase`: `update(board)` → 타깃 `updateBase` + `return board`

**② 커맨드 순수 입력 DTO화** (`d9b99f8`)
- `BingoBoardBaseUpdateCommand` 에서 `update(board, memberId)` 제거 → 요청 4필드만 담는 순수 입력 DTO
- 서비스가 `bingoBoard.updateBase(...)` 도메인 메서드를 직접 호출 (memo/open과 동일 형태, 커맨드가 애그리거트를 변경하지 않음)

## 설계 메모

- 리더 검증·`BingoGoal.create(goal, bingoSize)` VO 생성은 로드한 보드의 도메인 로직에 그대로 유지 → 서비스가 bingoSize 를 따로 쿼리하지 않음.
- API 시그니처/응답 스키마 불변 → **HTTP 계약·REST Docs·프론트 무변경**.
- `updateMembersPeriod`(publish-info)는 멤버 INSERT + 기간 변경이라 별도 슬라이스로 분리(다음 PR).

## 검증

- 서비스 단위 테스트(타깃 operation 호출 + 스냅샷 `update(any())` 0회 검증)
- 어댑터 persistence 테스트(제목/목표/기간만 변경·멤버/아이템 불변)
- 전체 `./gradlew build` 그린 (REST Docs 계약 유지 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)