### PR TITLE
refactor: 빙고 발행(PATCH /publish-info)을 타깃 operation 영속화로 전환

### DIFF
--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardUpdateService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardUpdateService.kt
@@ -26,8 +26,10 @@ class BingoBoardUpdateService(
     fun updateMembersPeriod(bingoBoardId: Long, memberId: Long, command: BingoBoardMembersPeriodUpdateCommand): BingoBoard {
         bingoBoardMembersValidator.validate(command.bingoMembers)
         val bingoBoard = bingoBoardQueryRepository.findOne(bingoBoardId)
-        command.update(bingoBoard, memberId)
-        return bingoBoardCommandRepository.update(bingoBoard)
+        val addedMembers = bingoBoard.updateBingoMembersPeriod(memberId, command.bingoMembers, command.since, command.until)
+        bingoBoardCommandRepository.addBingoMembers(bingoBoardId, addedMembers)
+        bingoBoardCommandRepository.updatePeriod(bingoBoardId, bingoBoard.period!!)
+        return bingoBoard
     }
 
     fun updateMemo(bingoBoardId: Long, memberId: Long, memo: String?): BingoBoard {

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoard.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoard.kt
@@ -90,10 +90,10 @@ class BingoBoard private constructor(
         this.period = BingoPeriod.create(since, until)
     }
 
-    fun updateBingoMembersPeriod(memberId: Long, bingoMembers: List<Long>, since: LocalDate, until: LocalDate) {
+    fun updateBingoMembersPeriod(memberId: Long, bingoMembers: List<Long>, since: LocalDate, until: LocalDate): List<BingoMember> {
         this.bingoMembers.validateLeaderOf(memberId, id)
         this.period = BingoPeriod.create(since, until)
-        this.bingoMembers.addNewMembers(bingoMembers)
+        return this.bingoMembers.addNewMembers(bingoMembers)
     }
 
     fun updateBingoMemo(memberId: Long, memo: String?) {

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoMembers.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoMembers.kt
@@ -33,8 +33,10 @@ class BingoMembers private constructor(val data: MutableList<BingoMember>) : Ite
         }
     }
 
-    fun addNewMembers(memberIds: List<Long>) {
-        data.addAll(memberIds.map { BingoMember.create(it) })
+    fun addNewMembers(memberIds: List<Long>): List<BingoMember> {
+        val newMembers = memberIds.map { BingoMember.create(it) }
+        data.addAll(newMembers)
+        return newMembers
     }
 
     fun inactivateOf(memberId: Long, bingoBoardId: Long) {

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardCommandRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardCommandRepository.kt
@@ -2,6 +2,7 @@ package com.beside.groubing.domain.bingo.domain.port
 
 import com.beside.groubing.domain.bingo.domain.BingoBoard
 import com.beside.groubing.domain.bingo.domain.BingoGoal
+import com.beside.groubing.domain.bingo.domain.BingoMember
 import com.beside.groubing.domain.bingo.domain.BingoPeriod
 
 interface BingoBoardCommandRepository {
@@ -10,6 +11,10 @@ interface BingoBoardCommandRepository {
     fun update(bingoBoard: BingoBoard): BingoBoard
 
     fun updateBase(bingoBoardId: Long, title: String, bingoGoal: BingoGoal, period: BingoPeriod)
+
+    fun addBingoMembers(bingoBoardId: Long, bingoMembers: List<BingoMember>)
+
+    fun updatePeriod(bingoBoardId: Long, period: BingoPeriod)
 
     fun updateMemo(bingoBoardId: Long, memo: String?)
 

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/payload/command/BingoBoardMembersPeriodUpdateCommand.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/payload/command/BingoBoardMembersPeriodUpdateCommand.kt
@@ -1,17 +1,12 @@
 package com.beside.groubing.domain.bingo.payload.command
 
-import com.beside.groubing.domain.bingo.domain.BingoBoard
 import java.time.LocalDate
 
 class BingoBoardMembersPeriodUpdateCommand private constructor(
     val bingoMembers: List<Long>,
-    private val since: LocalDate,
-    private val until: LocalDate
+    val since: LocalDate,
+    val until: LocalDate
 ) {
-    fun update(bingoBoard: BingoBoard, memberId: Long) {
-        bingoBoard.updateBingoMembersPeriod(memberId, bingoMembers, since, until)
-    }
-
     companion object {
         fun of(
             bingoMembers: List<Long>,

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardUpdateServiceTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardUpdateServiceTest.kt
@@ -2,14 +2,17 @@ package com.beside.groubing.domain.bingo.application
 
 import com.beside.groubing.aEnglishStudyBingoBoard
 import com.beside.groubing.domain.bingo.domain.BingoBoardMembersValidator
+import com.beside.groubing.domain.bingo.domain.BingoMember
 import com.beside.groubing.domain.bingo.domain.port.BingoBoardCommandRepository
 import com.beside.groubing.domain.bingo.domain.port.BingoBoardQueryRepository
 import com.beside.groubing.domain.bingo.payload.command.BingoBoardBaseUpdateCommand
+import com.beside.groubing.domain.bingo.payload.command.BingoBoardMembersPeriodUpdateCommand
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import java.time.LocalDate
 
@@ -47,6 +50,43 @@ class BingoBoardUpdateServiceTest : BehaviorSpec({
             then("기본정보가 변경된 도메인을 그대로 반환한다") {
                 result.title shouldBe newTitle
                 result.goal shouldBe newGoal
+                result.since shouldBe since
+                result.until shouldBe until
+            }
+        }
+    }
+
+    given("리더(memberId=1)가 멤버/기간 변경(발행)을 요청할 때") {
+        val leaderId = 1L
+        val bingoBoardId = 2L
+        val newMemberIds = listOf(4L, 5L)
+        val since = LocalDate.now()
+        val until = LocalDate.now().plusDays(7)
+        val command = BingoBoardMembersPeriodUpdateCommand.of(newMemberIds, since, until)
+        val bingoBoard = aEnglishStudyBingoBoard()
+        val addedMembersSlot = slot<List<BingoMember>>()
+
+        justRun { bingoBoardMembersValidator.validate(newMemberIds) }
+        every { bingoBoardQueryRepository.findOne(bingoBoardId) } returns bingoBoard
+        justRun { bingoBoardCommandRepository.addBingoMembers(bingoBoardId, capture(addedMembersSlot)) }
+        justRun { bingoBoardCommandRepository.updatePeriod(bingoBoardId, any()) }
+
+        `when`("updateMembersPeriod 를 호출하면") {
+            val result = bingoBoardUpdateService.updateMembersPeriod(bingoBoardId, leaderId, command)
+
+            then("멤버 검증 후 멤버 INSERT(addBingoMembers)·기간 UPDATE(updatePeriod) 타깃 경로를 타고 스냅샷 update 는 호출하지 않는다") {
+                verify(exactly = 1) { bingoBoardMembersValidator.validate(newMemberIds) }
+                verify(exactly = 1) { bingoBoardCommandRepository.addBingoMembers(bingoBoardId, any()) }
+                verify(exactly = 1) { bingoBoardCommandRepository.updatePeriod(bingoBoardId, any()) }
+                verify(exactly = 0) { bingoBoardCommandRepository.update(any()) }
+            }
+
+            then("새로 추가된 멤버만 영속화 경로로 전달한다") {
+                addedMembersSlot.captured.map { it.memberId } shouldBe newMemberIds
+            }
+
+            then("멤버목록·기간이 반영된 도메인을 그대로 반환한다") {
+                result.bingoMembers.memberIds().toSet() shouldBe setOf(1L, 2L, 3L, 7L, 4L, 5L)
                 result.since shouldBe since
                 result.until shouldBe until
             }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoBoardEntity.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoBoardEntity.kt
@@ -5,6 +5,7 @@ import com.beside.groubing.domain.bingo.domain.BingoBoardType
 import com.beside.groubing.domain.bingo.domain.BingoColor
 import com.beside.groubing.domain.bingo.domain.BingoGoal
 import com.beside.groubing.domain.bingo.domain.BingoItems
+import com.beside.groubing.domain.bingo.domain.BingoMember
 import com.beside.groubing.domain.bingo.domain.BingoMembers
 import com.beside.groubing.domain.bingo.domain.BingoPeriod
 import com.beside.groubing.global.domain.jpa.BaseAggregateRoot
@@ -82,6 +83,14 @@ class BingoBoardEntity(
     fun changeBase(title: String, bingoGoal: BingoGoal, period: BingoPeriod) {
         this.title = title
         this.bingoGoal = BingoGoalEmbeddable.from(bingoGoal)
+        this.period = BingoPeriodEmbeddable.from(period)
+    }
+
+    fun addBingoMembers(bingoMembers: List<BingoMember>) {
+        bingoMembers.forEach { this.bingoMembers.add(BingoMemberEntity.from(it)) }
+    }
+
+    fun changePeriod(period: BingoPeriod) {
         this.period = BingoPeriodEmbeddable.from(period)
     }
 

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
@@ -5,6 +5,7 @@ import com.beside.groubing.domain.bingo.domain.BingoBoard
 import com.beside.groubing.domain.bingo.domain.BingoCompleteMember
 import com.beside.groubing.domain.bingo.domain.BingoGoal
 import com.beside.groubing.domain.bingo.domain.BingoItems
+import com.beside.groubing.domain.bingo.domain.BingoMember
 import com.beside.groubing.domain.bingo.domain.BingoMembers
 import com.beside.groubing.domain.bingo.domain.BingoPeriod
 import com.beside.groubing.domain.bingo.domain.port.BingoBoardCommandRepository
@@ -39,6 +40,14 @@ class BingoBoardRepositoryAdapter(
 
     override fun updateBase(bingoBoardId: Long, title: String, bingoGoal: BingoGoal, period: BingoPeriod) {
         findActiveEntityById(bingoBoardId).changeBase(title, bingoGoal, period)
+    }
+
+    override fun addBingoMembers(bingoBoardId: Long, bingoMembers: List<BingoMember>) {
+        findActiveEntityById(bingoBoardId).addBingoMembers(bingoMembers)
+    }
+
+    override fun updatePeriod(bingoBoardId: Long, period: BingoPeriod) {
+        findActiveEntityById(bingoBoardId).changePeriod(period)
     }
 
     override fun updateMemo(bingoBoardId: Long, memo: String?) {

--- a/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapterTest.kt
+++ b/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapterTest.kt
@@ -1,14 +1,18 @@
 package com.beside.groubing.domain.bingo.repository
 
+import com.beside.groubing.aEmptyBingo
 import com.beside.groubing.aEnglishStudyBingoBoard
 import com.beside.groubing.domain.bingo.dao.BingoBoardListFindDao
 import com.beside.groubing.domain.bingo.domain.BingoGoal
+import com.beside.groubing.domain.bingo.domain.BingoMember
+import com.beside.groubing.domain.bingo.domain.BingoMemberType
 import com.beside.groubing.domain.bingo.domain.BingoPeriod
 import com.beside.groubing.domain.bingo.domain.BingoSize
 import com.beside.groubing.domain.bingo.entity.BingoBoardEntity
 import com.beside.groubing.global.config.QuerydslConfig
 import com.beside.groubing.persistence.PersistenceTest
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.context.annotation.Import
@@ -51,6 +55,58 @@ class BingoBoardRepositoryAdapterTest(
                 reloaded.period!!.until shouldBe newUntil
                 reloaded.bingoMembers.size shouldBe originalMemberCount
                 reloaded.bingoMembers.count { it.active } shouldBe originalActiveCount
+                reloaded.bingoItems.size shouldBe originalItemTitles.size
+                reloaded.bingoItems.sortedBy { it.id }.map { it.title } shouldBe originalItemTitles
+            }
+        }
+    }
+
+    describe("addBingoMembers") {
+        context("리더가 멤버를 추가하면") {
+            it("추가 멤버만 PARTICIPANT 로 INSERT 되고 기존 멤버/아이템은 그대로 유지된다") {
+                val saved = bingoBoardJpaRepository.save(BingoBoardEntity.from(aEmptyBingo()))
+                val savedId = saved.id
+                val originalMemberCount = saved.bingoMembers.size
+                val originalItemTitles = saved.bingoItems.sortedBy { it.id }.map { it.title }
+
+                bingoBoardRepositoryAdapter.addBingoMembers(
+                    savedId,
+                    listOf(BingoMember.create(2L), BingoMember.create(3L))
+                )
+                testEntityManager.flush()
+                testEntityManager.clear()
+
+                val reloaded = bingoBoardJpaRepository.findById(savedId).orElseThrow()
+                reloaded.bingoMembers.size shouldBe originalMemberCount + 2
+                reloaded.bingoMembers.map { it.memberId } shouldContainAll listOf(2L, 3L)
+                reloaded.bingoMembers.filter { it.memberId in setOf(2L, 3L) }.forEach {
+                    it.active shouldBe true
+                    it.bingoMemberType shouldBe BingoMemberType.PARTICIPANT
+                }
+                reloaded.bingoItems.size shouldBe originalItemTitles.size
+                reloaded.bingoItems.sortedBy { it.id }.map { it.title } shouldBe originalItemTitles
+            }
+        }
+    }
+
+    describe("updatePeriod") {
+        context("리더가 기간을 변경하면") {
+            it("기간만 갱신되고 멤버/아이템은 그대로 유지된다") {
+                val saved = bingoBoardJpaRepository.save(BingoBoardEntity.from(aEnglishStudyBingoBoard()))
+                val savedId = saved.id
+                val originalMemberCount = saved.bingoMembers.size
+                val originalItemTitles = saved.bingoItems.sortedBy { it.id }.map { it.title }
+                val newSince = LocalDate.now().plusDays(2)
+                val newUntil = LocalDate.now().plusDays(20)
+
+                bingoBoardRepositoryAdapter.updatePeriod(savedId, BingoPeriod.create(newSince, newUntil))
+                testEntityManager.flush()
+                testEntityManager.clear()
+
+                val reloaded = bingoBoardJpaRepository.findById(savedId).orElseThrow()
+                reloaded.period!!.since shouldBe newSince
+                reloaded.period!!.until shouldBe newUntil
+                reloaded.bingoMembers.size shouldBe originalMemberCount
                 reloaded.bingoItems.size shouldBe originalItemTitles.size
                 reloaded.bingoItems.sortedBy { it.id }.map { it.title } shouldBe originalItemTitles
             }


### PR DESCRIPTION
## 개요

빙고 operation 기반 영속화 전환의 **publish-info 슬라이스** (memo=#29 / open=#31 / base=#32 에 이은 후속).

`PATCH /publish-info`(멤버 추가 + 기간 변경, 발행)가 보드를 통째 로드·diff 하던 스냅샷 `update(board)` 대신, **추가 멤버 INSERT + 기간 UPDATE** 타깃 operation 만 타도록 전환한다.

## 변경 내용

**① 도메인 선행 변경** (`196287e`)
- `BingoMembers.addNewMembers` / `BingoBoard.updateBingoMembersPeriod` 가 새로 생성한 `BingoMember` 목록을 반환 → 추가 멤버만 INSERT 대상으로 넘기기 위함 (기존 호출부는 반환 무시, 동작 변화 없음)

**② operation 영속화 전환** (`9663456`)
- 포트: `addBingoMembers(id, members)` / `updatePeriod(id, period)`
- 엔티티: `addBingoMembers`(자식 INSERT) / `changePeriod` mutator
- 어댑터: 더티체킹 기반 타깃 영속화 — 아이템/완료멤버 diff 없음
- 서비스: 멤버 존재 검증 → 도메인(리더검증·멤버추가·기간) → 반환된 추가 멤버 INSERT + 기간 UPDATE → 보드 그대로 반환
- 커맨드: `update(board)` 제거해 순수 입력 DTO 화, 서비스가 `bingoBoard.updateBingoMembersPeriod(...)` 직접 호출 (memo/open/base 와 동일 형태)

## 설계 메모

- 추가된 멤버를 `id == 0L` 필터 같은 영속화 detail 에 의존하지 않고 **도메인 메서드 반환값**으로 식별 → 픽스처/프로덕션 동작 차이 없음.
- 보드를 로드·도메인 변경하므로 응답은 `board.bingoMembers.memberIds()` 로 그대로 재구성 → `findMemberIds` 별도 쿼리 불필요, **응답 스키마 불변**(REST Docs·프론트 무변경).
- 멤버 존재 검증(`BingoBoardMembersValidator`)·리더 검증(도메인)은 그대로 유지.

## 검증

- 서비스 단위 테스트(검증 → 추가 멤버만 INSERT·기간 UPDATE 호출, 스냅샷 `update(any())` 0회, 반환 memberIds·기간 확인)
- 어댑터 persistence 테스트(`addBingoMembers`: 추가 멤버만 PARTICIPANT INSERT·기존 멤버/아이템 불변 / `updatePeriod`: 기간만 변경·멤버/아이템 불변)
- 전체 `./gradlew build` 그린

## 머지 순서

`refactor/bingo-operation-base`(#32)와 동일 파일(포트·서비스·엔티티·어댑터)을 건드리므로, #32 머지 후 본 브랜치 rebase 가 필요할 수 있음(dev 기준 독립 브랜치).

🤖 Generated with [Claude Code](https://claude.com/claude-code)