### PR TITLE
refactor: 빙고 나가기(POST /leave)를 타깃 영속화로 전환

### DIFF
--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoMemberLeaveService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoMemberLeaveService.kt
@@ -14,7 +14,6 @@ class BingoMemberLeaveService(
     fun leave(memberId: Long, bingoId: Long) {
         val bingoBoard = bingoBoardQueryRepository.findOne(bingoId)
         bingoBoard.validateCanLeave(memberId)
-        bingoBoard.inactiveByMemberId(memberId)
-        bingoBoardCommandRepository.update(bingoBoard)
+        bingoBoardCommandRepository.deactivateBingoMember(bingoId, memberId)
     }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoard.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoard.kt
@@ -183,7 +183,8 @@ class BingoBoard private constructor(
     }
 
     fun validateCanLeave(memberId: Long) {
-        if (isLeader(memberId)) {
+        val bingoMember = bingoMembers.findOf(memberId, id)
+        if (bingoMember.isLeader()) {
             throw BingoIllegalStateException("그룹 빙고 리더는 빙고를 나갈 수 없습니다.")
         }
     }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardCommandRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardCommandRepository.kt
@@ -20,5 +20,7 @@ interface BingoBoardCommandRepository {
 
     fun updateOpen(bingoBoardId: Long, open: Boolean)
 
+    fun deactivateBingoMember(bingoBoardId: Long, memberId: Long)
+
     fun inactivateAllOf(memberId: Long)
 }

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/application/BingoMemberLeaveServiceTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/application/BingoMemberLeaveServiceTest.kt
@@ -1,0 +1,56 @@
+package com.beside.groubing.domain.bingo.application
+
+import com.beside.groubing.aEnglishStudyBingoBoard
+import com.beside.groubing.domain.bingo.domain.port.BingoBoardCommandRepository
+import com.beside.groubing.domain.bingo.domain.port.BingoBoardQueryRepository
+import com.beside.groubing.domain.bingo.exception.BingoIllegalStateException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+
+class BingoMemberLeaveServiceTest : BehaviorSpec({
+    val bingoBoardQueryRepository = mockk<BingoBoardQueryRepository>()
+    val bingoBoardCommandRepository = mockk<BingoBoardCommandRepository>()
+    val bingoMemberLeaveService = BingoMemberLeaveService(
+        bingoBoardQueryRepository,
+        bingoBoardCommandRepository
+    )
+
+    given("참여자(memberId=2)가 빙고 나가기를 요청할 때") {
+        val participantId = 2L
+        val bingoBoardId = 2L
+        val bingoBoard = aEnglishStudyBingoBoard()
+
+        every { bingoBoardQueryRepository.findOne(bingoBoardId) } returns bingoBoard
+        justRun { bingoBoardCommandRepository.deactivateBingoMember(bingoBoardId, participantId) }
+
+        `when`("leave 를 호출하면") {
+            bingoMemberLeaveService.leave(participantId, bingoBoardId)
+
+            then("타깃 비활성화 경로(deactivateBingoMember)를 타고 스냅샷 update 는 호출하지 않는다") {
+                verify(exactly = 1) { bingoBoardCommandRepository.deactivateBingoMember(bingoBoardId, participantId) }
+                verify(exactly = 0) { bingoBoardCommandRepository.update(any()) }
+            }
+        }
+    }
+
+    given("리더(memberId=1)가 빙고 나가기를 요청할 때") {
+        val leaderId = 1L
+        val bingoBoardId = 2L
+        val bingoBoard = aEnglishStudyBingoBoard()
+
+        every { bingoBoardQueryRepository.findOne(bingoBoardId) } returns bingoBoard
+
+        `when`("leave 를 호출하면") {
+            then("리더는 나갈 수 없어 예외가 발생하고 비활성화는 호출되지 않는다") {
+                shouldThrow<BingoIllegalStateException> {
+                    bingoMemberLeaveService.leave(leaderId, bingoBoardId)
+                }
+                verify(exactly = 0) { bingoBoardCommandRepository.deactivateBingoMember(any(), any()) }
+            }
+        }
+    }
+})

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoBoardEntity.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoBoardEntity.kt
@@ -102,6 +102,13 @@ class BingoBoardEntity(
         this.open = open
     }
 
+    fun deactivateMember(memberId: Long) {
+        bingoMembers.filter { it.memberId == memberId }.forEach { it.deactivate() }
+        bingoItems.forEach { item ->
+            item.completeMembers.filter { it.memberId == memberId }.forEach { it.deactivate() }
+        }
+    }
+
     fun applyChanges(domain: BingoBoard) {
         this.title = domain.title
         this.open = domain.open

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoCompleteMemberEntity.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoCompleteMemberEntity.kt
@@ -23,6 +23,10 @@ class BingoCompleteMemberEntity(
     var active: Boolean = active
         private set
 
+    fun deactivate() {
+        this.active = false
+    }
+
     fun applyChanges(domain: BingoCompleteMember) {
         this.active = domain.active
     }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoMemberEntity.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoMemberEntity.kt
@@ -30,6 +30,10 @@ class BingoMemberEntity(
     var active: Boolean = active
         private set
 
+    fun deactivate() {
+        this.active = false
+    }
+
     fun applyChanges(domain: BingoMember) {
         this.active = domain.active
     }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
@@ -58,6 +58,10 @@ class BingoBoardRepositoryAdapter(
         findActiveEntityById(bingoBoardId).changeOpen(open)
     }
 
+    override fun deactivateBingoMember(bingoBoardId: Long, memberId: Long) {
+        findActiveEntityById(bingoBoardId).deactivateMember(memberId)
+    }
+
     override fun inactivateAllOf(memberId: Long) {
         bingoBoardListFindDao.find(memberId)
             .forEach { entity ->

--- a/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapterTest.kt
+++ b/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapterTest.kt
@@ -13,6 +13,7 @@ import com.beside.groubing.global.config.QuerydslConfig
 import com.beside.groubing.persistence.PersistenceTest
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.context.annotation.Import
@@ -106,6 +107,33 @@ class BingoBoardRepositoryAdapterTest(
                 val reloaded = bingoBoardJpaRepository.findById(savedId).orElseThrow()
                 reloaded.period!!.since shouldBe newSince
                 reloaded.period!!.until shouldBe newUntil
+                reloaded.bingoMembers.size shouldBe originalMemberCount
+                reloaded.bingoItems.size shouldBe originalItemTitles.size
+                reloaded.bingoItems.sortedBy { it.id }.map { it.title } shouldBe originalItemTitles
+            }
+        }
+    }
+
+    describe("deactivateBingoMember") {
+        context("참여자가 빙고를 나가면") {
+            it("해당 멤버와 그의 완료기록만 비활성화되고 다른 멤버/아이템은 그대로 유지된다") {
+                val board = aEnglishStudyBingoBoard()
+                board.completeBingoItem(bingoItemId = 1L, memberId = 2L)
+                val saved = bingoBoardJpaRepository.save(BingoBoardEntity.from(board))
+                val savedId = saved.id
+                val originalMemberCount = saved.bingoMembers.size
+                val originalItemTitles = saved.bingoItems.sortedBy { it.id }.map { it.title }
+
+                bingoBoardRepositoryAdapter.deactivateBingoMember(savedId, 2L)
+                testEntityManager.flush()
+                testEntityManager.clear()
+
+                val reloaded = bingoBoardJpaRepository.findById(savedId).orElseThrow()
+                reloaded.bingoMembers.first { it.memberId == 2L }.active shouldBe false
+                reloaded.bingoMembers.filter { it.memberId != 2L }.forEach { it.active shouldBe true }
+                val completeMembersOfLeaver = reloaded.bingoItems.flatMap { it.completeMembers }.filter { it.memberId == 2L }
+                completeMembersOfLeaver.shouldNotBeEmpty()
+                completeMembersOfLeaver.forEach { it.active shouldBe false }
                 reloaded.bingoMembers.size shouldBe originalMemberCount
                 reloaded.bingoItems.size shouldBe originalItemTitles.size
                 reloaded.bingoItems.sortedBy { it.id }.map { it.title } shouldBe originalItemTitles


### PR DESCRIPTION
## 개요

빙고 operation 기반 영속화 전환의 **leave 슬라이스** (memo=#29 / open=#31 / base=#32 / publish-info=#33 에 이은 후속).

`POST /{id}/leave`(나가기)가 보드를 통째 로드·diff 하던 스냅샷 `update(board)` 대신, 나가는 멤버와 그의 완료기록만 비활성화하는 **타깃 operation**(`deactivateBingoMember`)을 타도록 전환한다.

## 변경 내용

- **포트**: `deactivateBingoMember(bingoBoardId, memberId)` 추가
- **엔티티**: `BingoBoardEntity.deactivateMember`(해당 멤버 + 그의 완료멤버 `active=false`), `BingoMemberEntity`/`BingoCompleteMemberEntity.deactivate` mutator
- **어댑터**: 서비스가 검증용으로 이미 로드한 보드 엔티티(같은 트랜잭션 1차 캐시 히트)를 재사용해 **더티체킹으로 해당 행만 UPDATE** — 아이템/타 멤버 diff 없음
- **서비스**: `findOne → validateCanLeave → deactivateBingoMember` (스냅샷 `update` 미사용)
- **도메인**: `validateCanLeave` 를 `findOf` 기반(미존재 멤버 예외) + 리더 검사로 보강 → 멤버십 검증을 위해 호출하던 `inactiveByMemberId`(스냅샷용) 의존 제거

## 설계 메모

- 자식 엔티티(멤버·완료멤버)가 부모 FK를 쿼리 필드로 노출하지 않아 순수 bulk SQL은 서브쿼리가 필요 → 서비스가 리더/멤버십 검증을 위해 어차피 보드를 로드하므로, **그 캐시 엔티티를 재사용한 더티체킹**이 추가 쿼리 0 + 타깃 UPDATE로 가장 단순(memo/open/base 와 동일 결).
- 응답은 기존과 동일 `Unit` → 계약 불변.
- `inactiveByMemberId` 는 회원 탈퇴(withdrawal) 경로가 계속 사용하므로 유지(다음 withdrawal 슬라이스에서 전환 예정).

## 검증

- 서비스 단위 테스트(신규): 참여자 leave → `deactivateBingoMember` 호출·스냅샷 `update` 0회 / 리더 leave → 예외, 비활성화 미호출
- 어댑터 persistence 테스트: 나가는 멤버 + 그의 완료기록만 `active=false`, 타 멤버/아이템 불변
- 전체 `./gradlew build` 그린

## 머지 순서

dev 기준 독립 브랜치. 단독 머지 가능(현재 dev 기준이라 충돌 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)