### PR TITLE
feat: 회원 탈퇴 즉시 soft-delete (deletedAt) — 탈퇴 Phase 1

### DIFF
--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/notification/event/BingoEventHandler.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/notification/event/BingoEventHandler.kt
@@ -35,7 +35,7 @@ class BingoEventHandler(
         save(event.bingoBoardId, event.memberId, event.toMessage(nicknameOf(event.memberId)))
     }
 
-    private fun nicknameOf(memberId: Long): String = memberQueryRepository.findById(memberId).nickname
+    private fun nicknameOf(memberId: Long): String = memberQueryRepository.findActiveById(memberId).nickname
 
     private fun save(bingoBoardId: Long, memberId: Long, message: String) {
         notificationRepository.save(

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendTargetsFindApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/friend/api/FriendTargetsFindApiTest.kt
@@ -37,6 +37,7 @@ class FriendTargetsFindApiTest(
                     fcmToken = null,
                     notificationReceive = true,
                     active = true,
+                    deletedAt = null,
                     profileUrl = null
                 )
             }

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/LoginApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/LoginApiTest.kt
@@ -60,6 +60,7 @@ class LoginApiTest(
                 fcmToken = fcmToken,
                 notificationReceive = true,
                 active = true,
+                deletedAt = null,
                 profileUrl = null
             )
             every { loginService.login(any()) } returns AuthenticatedMember(member, jwt)

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/SignUpApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/SignUpApiTest.kt
@@ -55,6 +55,7 @@ class SignUpApiTest(
                 fcmToken = null,
                 notificationReceive = true,
                 active = true,
+                deletedAt = null,
                 profileUrl = null
             )
             every { signUpService.signUp(any()) } returns AuthenticatedMember(member, token)

--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/SocialLoginApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/member/api/SocialLoginApiTest.kt
@@ -59,6 +59,7 @@ class SocialLoginApiTest(
                 fcmToken = fcmToken,
                 notificationReceive = true,
                 active = true,
+                deletedAt = null,
                 profileUrl = null
             )
             every { socialLoginService.login(any()) } returns AuthenticatedMember(member, jwt)

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/auth/application/MemberPasswordResetService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/auth/application/MemberPasswordResetService.kt
@@ -16,7 +16,7 @@ class MemberPasswordResetService(
     private val passwordEncryptor: PasswordEncryptor
 ) {
     fun reset(id: Long, beforePassword: String, afterPassword: String) {
-        val member = memberQueryRepository.findById(id)
+        val member = memberQueryRepository.findActiveById(id)
         passwordVerifier.verify(beforePassword, member.password)
         memberCommandRepository.update(member.withPassword(passwordEncryptor.encode(afterPassword)))
     }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/auth/application/SocialLoginService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/auth/application/SocialLoginService.kt
@@ -23,7 +23,7 @@ class SocialLoginService(
 ) {
     fun login(socialLoginCommand: SocialLoginCommand): AuthenticatedMember {
         val socialInfo = findOrCreateSocialInfo(socialLoginCommand)
-        val member = memberQueryRepository.findById(socialInfo.memberId)
+        val member = memberQueryRepository.findActiveById(socialInfo.memberId)
         val updated = memberCommandRepository.update(member.withFcmToken(socialLoginCommand.fcmToken))
         return AuthenticatedMember(updated, tokenManager.generateAccessToken(updated.id, updated.role.name))
     }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardCreateService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardCreateService.kt
@@ -14,7 +14,7 @@ class BingoBoardCreateService(
     private val memberQueryRepository: MemberQueryRepository
 ) {
     fun create(command: BingoBoardCreateCommand): BingoBoard {
-        memberQueryRepository.findById(command.memberId)
+        memberQueryRepository.findActiveById(command.memberId)
         return bingoBoardCommandRepository.save(command.toNewBingoBoard())
     }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardFindService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardFindService.kt
@@ -15,7 +15,7 @@ class BingoBoardFindService(
     fun findOne(memberId: Long, boardId: Long): BingoBoardDetail {
         val bingoBoard = bingoBoardQueryRepository.findOne(boardId)
         bingoBoard.validateViewableBy(memberId)
-        val viewer = memberQueryRepository.findById(memberId)
+        val viewer = memberQueryRepository.findActiveById(memberId)
         val otherMembers = memberQueryRepository.findAll(bingoBoard.otherActiveMemberIdsOf(memberId))
         return BingoBoardDetail(bingoBoard, viewer, otherMembers)
     }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardCommandRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardCommandRepository.kt
@@ -21,6 +21,4 @@ interface BingoBoardCommandRepository {
     fun updateOpen(bingoBoardId: Long, open: Boolean)
 
     fun deactivateBingoMember(bingoBoardId: Long, memberId: Long)
-
-    fun inactivateAllOf(memberId: Long)
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/friend/domain/FriendAddValidator.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/friend/domain/FriendAddValidator.kt
@@ -24,7 +24,7 @@ class FriendAddValidator(
     }
 
     private fun validateMembersExist(inviterId: Long, inviteeId: Long) {
-        memberQueryRepository.findById(inviterId)
-        memberQueryRepository.findById(inviteeId)
+        memberQueryRepository.findActiveById(inviterId)
+        memberQueryRepository.findActiveById(inviteeId)
     }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/application/MemberNicknameEditService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/application/MemberNicknameEditService.kt
@@ -15,7 +15,7 @@ class MemberNicknameEditService(
     @Transactional
     fun edit(id: Long, nickname: String) {
         nicknameUniquenessValidator.validate(nickname)
-        val member = memberQueryRepository.findById(id)
+        val member = memberQueryRepository.findActiveById(id)
         memberCommandRepository.update(member.withNickname(nickname))
     }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/application/MemberNotiUpdateService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/application/MemberNotiUpdateService.kt
@@ -20,7 +20,7 @@ class MemberNotiUpdateService(
     }
 
     private fun updateReceive(memberId: Long, receive: Boolean) {
-        val member = memberQueryRepository.findById(memberId)
+        val member = memberQueryRepository.findActiveById(memberId)
         memberCommandRepository.update(member.withNotificationReceive(receive))
     }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/application/WithdrawalService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/application/WithdrawalService.kt
@@ -1,6 +1,5 @@
 package com.beside.groubing.domain.member.application
 
-import com.beside.groubing.domain.bingo.domain.port.BingoBoardCommandRepository
 import com.beside.groubing.domain.member.domain.port.MemberCommandRepository
 import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
 import org.springframework.stereotype.Service
@@ -10,12 +9,11 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class WithdrawalService(
     private val memberQueryRepository: MemberQueryRepository,
-    private val memberCommandRepository: MemberCommandRepository,
-    private val bingoBoardCommandRepository: BingoBoardCommandRepository
+    private val memberCommandRepository: MemberCommandRepository
 ) {
     fun withdrawal(memberId: Long) {
         val member = memberQueryRepository.findById(memberId)
-        memberCommandRepository.update(member.withdrawn())
-        bingoBoardCommandRepository.inactivateAllOf(memberId)
+        member.validateWithdrawable()
+        memberCommandRepository.withdraw(memberId)
     }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/Member.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/Member.kt
@@ -1,5 +1,8 @@
 package com.beside.groubing.domain.member.domain
 
+import com.beside.groubing.domain.member.exception.MemberInputException
+import java.time.LocalDateTime
+
 data class Member(
     val id: Long,
     val loginId: String?,
@@ -10,6 +13,7 @@ data class Member(
     val fcmToken: String?,
     val notificationReceive: Boolean,
     val active: Boolean,
+    val deletedAt: LocalDateTime?,
     val profileUrl: String?
 ) {
     fun withFcmToken(fcmToken: String?): Member = copy(fcmToken = fcmToken)
@@ -20,9 +24,10 @@ data class Member(
 
     fun withNotificationReceive(receive: Boolean): Member = copy(notificationReceive = receive)
 
-    fun withdrawn(): Member {
-        check(active) { "이미 탈퇴한 회원입니다." }
-        return copy(active = false)
+    fun validateWithdrawable() {
+        if (!active) {
+            throw MemberInputException("이미 탈퇴한 회원입니다.")
+        }
     }
 
     fun hasNickname(): Boolean = nickname.isNotBlank()

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberCommandRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberCommandRepository.kt
@@ -3,11 +3,14 @@ package com.beside.groubing.domain.member.domain.port
 import com.beside.groubing.domain.member.domain.Member
 import com.beside.groubing.domain.member.domain.NewMember
 import com.beside.groubing.domain.common.file.domain.FileInfo
+import java.time.LocalDateTime
 
 interface MemberCommandRepository {
     fun save(newMember: NewMember): Member
 
     fun update(member: Member): Member
+
+    fun withdraw(memberId: Long, now: LocalDateTime = LocalDateTime.now())
 
     fun editProfileOrNull(memberId: Long, newProfile: FileInfo): FileInfo?
 

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberQueryRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberQueryRepository.kt
@@ -5,6 +5,8 @@ import com.beside.groubing.domain.member.domain.Member
 interface MemberQueryRepository {
     fun findById(id: Long): Member
 
+    fun findActiveById(id: Long): Member
+
     fun findOneByLoginId(loginId: String): Member
 
     fun findAllSortedByNickname(): List<Member>

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/auth/application/SocialLoginServiceTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/auth/application/SocialLoginServiceTest.kt
@@ -29,7 +29,7 @@ class SocialLoginServiceTest : BehaviorSpec({
 
     Given("SocialLoginService가 주어졌을 때") {
         fun prepareMock(existingMember: Member, existingSocialInfo: SocialInfo? = null) {
-            every { mockMemberQueryRepository.findById(any()) } returns existingMember
+            every { mockMemberQueryRepository.findActiveById(any()) } returns existingMember
             every { mockMemberCommandRepository.update(any()) } returns existingMember
             every { mockSocialInfoRepository.findBySocialIdAndSocialTypeOrNull(any(), any()) } returns existingSocialInfo
             every { mockTokenManager.generateAccessToken(any(), any()) } returns "token"
@@ -48,6 +48,7 @@ class SocialLoginServiceTest : BehaviorSpec({
             fcmToken = null,
             notificationReceive = true,
             active = true,
+            deletedAt = null,
             profileUrl = null
         )
 

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/friend/domain/FriendAddValidatorTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/friend/domain/FriendAddValidatorTest.kt
@@ -21,8 +21,8 @@ class FriendAddValidatorTest : BehaviorSpec({
     Given("차단 관계가 없고 두 회원 모두 존재할 때") {
         every { blockedMemberRepository.exists(inviterId, inviteeId) } returns false
         every { blockedMemberRepository.exists(inviteeId, inviterId) } returns false
-        every { memberQueryRepository.findById(inviterId) } returns mockk<Member>()
-        every { memberQueryRepository.findById(inviteeId) } returns mockk<Member>()
+        every { memberQueryRepository.findActiveById(inviterId) } returns mockk<Member>()
+        every { memberQueryRepository.findActiveById(inviteeId) } returns mockk<Member>()
 
         When("validate 호출") {
             Then("예외가 발생하지 않는다") {
@@ -55,8 +55,8 @@ class FriendAddValidatorTest : BehaviorSpec({
 
     Given("상대방이 존재하지 않는 회원인 경우") {
         every { blockedMemberRepository.exists(any(), any()) } returns false
-        every { memberQueryRepository.findById(inviterId) } returns mockk<Member>()
-        every { memberQueryRepository.findById(inviteeId) } throws MemberInputException("회원이 존재하지 않습니다.")
+        every { memberQueryRepository.findActiveById(inviterId) } returns mockk<Member>()
+        every { memberQueryRepository.findActiveById(inviteeId) } throws MemberInputException("회원이 존재하지 않습니다.")
 
         When("validate 호출") {
             Then("MemberInputException 이 전파된다") {

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/member/application/WithdrawalServiceTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/member/application/WithdrawalServiceTest.kt
@@ -1,0 +1,64 @@
+package com.beside.groubing.domain.member.application
+
+import com.beside.groubing.domain.member.domain.Member
+import com.beside.groubing.domain.member.domain.MemberRole
+import com.beside.groubing.domain.member.domain.MemberType
+import com.beside.groubing.domain.member.domain.port.MemberCommandRepository
+import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
+import com.beside.groubing.domain.member.exception.MemberInputException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+
+class WithdrawalServiceTest : BehaviorSpec({
+    val mockMemberQueryRepository = mockk<MemberQueryRepository>()
+    val mockMemberCommandRepository = mockk<MemberCommandRepository>()
+    val withdrawalService = WithdrawalService(mockMemberQueryRepository, mockMemberCommandRepository)
+
+    fun aMember(active: Boolean) = Member(
+        id = 1L,
+        loginId = "groubing",
+        password = "encoded",
+        nickname = "nickname",
+        role = MemberRole.MEMBER,
+        memberType = MemberType.CLASSIC,
+        fcmToken = null,
+        notificationReceive = true,
+        active = active,
+        deletedAt = null,
+        profileUrl = null
+    )
+
+    Given("활성 회원이 탈퇴를 요청했을 때") {
+        val memberId = 1L
+        every { mockMemberQueryRepository.findById(memberId) } returns aMember(active = true)
+        every { mockMemberCommandRepository.withdraw(memberId, any<LocalDateTime>()) } just Runs
+
+        When("withdrawal 을 호출하면") {
+            withdrawalService.withdrawal(memberId)
+
+            Then("해당 회원의 soft-delete(withdraw) 가 호출된다") {
+                verify(exactly = 1) { mockMemberCommandRepository.withdraw(memberId, any<LocalDateTime>()) }
+            }
+        }
+    }
+
+    Given("이미 탈퇴한 회원이 탈퇴를 다시 요청했을 때") {
+        val memberId = 1L
+        every { mockMemberQueryRepository.findById(memberId) } returns aMember(active = false)
+
+        When("withdrawal 을 호출하면") {
+            Then("이미 탈퇴한 회원 예외가 발생하고 withdraw 는 호출되지 않는다") {
+                shouldThrow<MemberInputException> {
+                    withdrawalService.withdrawal(memberId)
+                }
+                verify(exactly = 0) { mockMemberCommandRepository.withdraw(any(), any()) }
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/member/domain/MemberTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/member/domain/MemberTest.kt
@@ -1,0 +1,46 @@
+package com.beside.groubing.domain.member.domain
+
+import com.beside.groubing.domain.member.exception.MemberInputException
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class MemberTest : BehaviorSpec({
+
+    fun aMember(active: Boolean) = Member(
+        id = 1L,
+        loginId = "groubing",
+        password = "encoded",
+        nickname = "nickname",
+        role = MemberRole.MEMBER,
+        memberType = MemberType.CLASSIC,
+        fcmToken = null,
+        notificationReceive = true,
+        active = active,
+        deletedAt = null,
+        profileUrl = null
+    )
+
+    Given("활성 상태의 회원이 주어졌을 때") {
+        val member = aMember(active = true)
+
+        When("validateWithdrawable 을 호출하면") {
+            Then("예외가 발생하지 않는다") {
+                shouldNotThrowAny { member.validateWithdrawable() }
+            }
+        }
+    }
+
+    Given("이미 탈퇴한 회원이 주어졌을 때") {
+        val member = aMember(active = false)
+
+        When("validateWithdrawable 을 호출하면") {
+            Then("이미 탈퇴한 회원이라는 예외가 발생한다") {
+                shouldThrow<MemberInputException> {
+                    member.validateWithdrawable()
+                }.message shouldBe "이미 탈퇴한 회원입니다."
+            }
+        }
+    }
+})

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
@@ -62,17 +62,6 @@ class BingoBoardRepositoryAdapter(
         findActiveEntityById(bingoBoardId).deactivateMember(memberId)
     }
 
-    override fun inactivateAllOf(memberId: Long) {
-        bingoBoardListFindDao.find(memberId)
-            .forEach { entity ->
-                val domain = entity.toDomain()
-                domain.inactiveByMemberId(memberId)
-                entity.applyChanges(domain)
-                syncBingoMembers(entity.bingoMembers, domain.bingoMembers)
-                syncBingoItems(entity.bingoItems, domain.bingoItems)
-            }
-    }
-
     override fun findOne(id: Long): BingoBoard = findActiveEntityById(id).toDomain()
 
     override fun findAllOf(memberId: Long): List<BingoBoard> =

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/entity/MemberEntity.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/entity/MemberEntity.kt
@@ -18,6 +18,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "MEMBERS")
@@ -57,6 +58,10 @@ class MemberEntity(
     var active: Boolean = true
         private set
 
+    @Column(name = "DELETED_AT")
+    var deletedAt: LocalDateTime? = null
+        private set
+
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumn(name = "PROFILE_ID")
     var profile: FileInfoEntity? = null
@@ -67,6 +72,11 @@ class MemberEntity(
         this.fcmToken = member.fcmToken
         this.notificationReceive = member.notificationReceive
         this.active = member.active
+    }
+
+    fun withdraw(now: LocalDateTime) {
+        this.active = false
+        this.deletedAt = now
     }
 
     fun editProfile(profile: FileInfoEntity) {
@@ -87,6 +97,7 @@ class MemberEntity(
         fcmToken = fcmToken,
         notificationReceive = notificationReceive,
         active = active,
+        deletedAt = deletedAt,
         profileUrl = profile?.toDomain()?.url
     )
 

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapter.kt
@@ -11,6 +11,7 @@ import com.beside.groubing.domain.common.file.entity.FileInfoEntity
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 class MemberRepositoryAdapter(
@@ -25,20 +26,24 @@ class MemberRepositoryAdapter(
     }
 
     override fun update(member: Member): Member {
-        val entity = findEntityById(member.id)
+        val entity = findActiveEntityById(member.id)
         entity.applyChanges(member)
         return entity.toDomain()
     }
 
+    override fun withdraw(memberId: Long, now: LocalDateTime) {
+        findActiveEntityById(memberId).withdraw(now)
+    }
+
     override fun editProfileOrNull(memberId: Long, newProfile: FileInfo): FileInfo? {
-        val entity = findEntityById(memberId)
+        val entity = findActiveEntityById(memberId)
         val previous = entity.profile?.toDomain()
         entity.editProfile(FileInfoEntity.from(newProfile))
         return previous
     }
 
     override fun deleteProfileOrNull(memberId: Long): FileInfo? {
-        val entity = findEntityById(memberId)
+        val entity = findActiveEntityById(memberId)
         val previous = entity.profile?.toDomain()
         entity.deleteProfile()
         return previous
@@ -46,6 +51,10 @@ class MemberRepositoryAdapter(
 
     override fun findById(id: Long): Member {
         return findEntityById(id).toDomain()
+    }
+
+    override fun findActiveById(id: Long): Member {
+        return findActiveEntityById(id).toDomain()
     }
 
     override fun findOneByLoginId(loginId: String): Member {
@@ -79,8 +88,13 @@ class MemberRepositoryAdapter(
         return memberJpaRepository.countByIdInAndActiveTrue(ids)
     }
 
-    private fun findEntityById(id: Long): MemberEntity {
-        return memberJpaRepository.findByIdAndActiveTrue(id)
-            ?: throw MemberInputException("존재하지 않는 유저 입니다.")
+    private fun findActiveEntityById(id: Long): MemberEntity {
+        return memberJpaRepository.findByIdAndActiveTrue(id) ?: throw memberNotFound()
     }
+
+    private fun findEntityById(id: Long): MemberEntity {
+        return memberJpaRepository.findById(id).orElseThrow { memberNotFound() }
+    }
+
+    private fun memberNotFound() = MemberInputException("존재하지 않는 유저 입니다.")
 }

--- a/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapterTest.kt
+++ b/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapterTest.kt
@@ -9,11 +9,13 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.context.annotation.Import
+import java.time.LocalDateTime
 
 @PersistenceTest
 @Import(MemberRepositoryAdapter::class)
 class MemberRepositoryAdapterTest(
-    private val memberRepositoryAdapter: MemberRepositoryAdapter
+    private val memberRepositoryAdapter: MemberRepositoryAdapter,
+    private val memberJpaRepository: MemberJpaRepository
 ) : FunSpec({
 
     fun newMember(loginId: String?, nickname: String) = NewMember(
@@ -45,5 +47,26 @@ class MemberRepositoryAdapterTest(
         shouldThrow<MemberInputException> {
             memberRepositoryAdapter.save(newMember(loginId = "idB", nickname = "dupNick"))
         }
+    }
+
+    test("withdraw 하면 회원이 비활성화되고 deletedAt 이 기록된다") {
+        val saved = memberRepositoryAdapter.save(newMember(loginId = "leaver", nickname = "leaverNick"))
+        val now = LocalDateTime.now()
+
+        memberRepositoryAdapter.withdraw(saved.id, now)
+
+        val entity = memberJpaRepository.findById(saved.id).orElseThrow()
+        entity.active shouldBe false
+        entity.deletedAt shouldBe now
+    }
+
+    test("탈퇴한 회원은 findById 로는 조회되지만 findActiveById 로는 조회되지 않는다") {
+        val saved = memberRepositoryAdapter.save(newMember(loginId = "wd", nickname = "wdNick"))
+        memberRepositoryAdapter.withdraw(saved.id, LocalDateTime.now())
+
+        memberRepositoryAdapter.findById(saved.id).active shouldBe false
+        shouldThrow<MemberInputException> {
+            memberRepositoryAdapter.findActiveById(saved.id)
+        }.message shouldBe "존재하지 않는 유저 입니다."
     }
 })


### PR DESCRIPTION
## 개요
회원 탈퇴 정책 **Phase 1**. 탈퇴 요청 **즉시** 회원을 soft-delete(`active=false` + `deletedAt`)한다.
(plan: `docs/plan/202606/member-withdrawal-policy.plan.md`)

## 설계
빙고 `leave` 슬라이스와 동일한 **load → 도메인 검증 → 타깃 operation** 패턴:
```kotlin
fun withdrawal(memberId: Long) {
    val member = memberQueryRepository.findById(memberId)  // 탈퇴자 포함 조회
    member.validateWithdrawable()                          // 도메인 불변식
    memberCommandRepository.withdraw(memberId, LocalDateTime.now())
}
```

## 변경 사항
- `Member.validateWithdrawable()` — active=false면 `MemberInputException("이미 탈퇴한 회원입니다.")`. `Member.deletedAt` 필드 추가(Phase 2 익명화·Phase 3 스캔이 읽음).
- `MemberCommandRepository.withdraw(memberId, now)` 타깃 op — 어댑터가 활성 엔티티 로드 → `entity.withdraw(now)`(더티체킹)로 `active`/`deletedAt`만 변경. `MemberEntity`에 `DELETED_AT` 컬럼 + dumb mutator.
- **`MemberQueryRepository.findById` 의미 정직화**: 기존 `findById`가 실제로는 `findByIdAndActiveTrue`(활성만)였음 → `findById`(필터 없음) / `findActiveById`(활성만)로 분리. 기존 호출처 9곳(friend·auth·bingo·notification)은 `findActiveById`로 전환(활성 의미 유지). 어댑터 헬퍼도 `findEntityById`/`findActiveEntityById`/`memberNotFound()`로 정리.
- (정리) 탈퇴 전용이던 `inactivateAllOf` 스냅샷 루프 제거. 그룹 빙고는 탈퇴 시 미관여(탈퇴자는 참여자로 보존 → Phase 2 표시 익명화).

## 테스트
- `MemberTest`(validateWithdrawable), `WithdrawalServiceTest`(정상/재탈퇴 차단), `MemberRepositoryAdapterTest`(withdraw, findById vs findActiveById), 영향받은 `FriendAddValidatorTest`/`SocialLoginServiceTest` 갱신.
- `:domain:gb-domain-core:test` + `:infrastructure:storage:gb-db-core:test` + `:boot:gb-boot-web:test` **BUILD SUCCESSFUL**.

## 후속
- **Phase 2**: 그룹 빙고 상세·피드에서 탈퇴자 → '탈퇴한 회원' 익명 표시(`deletedAt` 기준).
- **Phase 3**: 1년 경과 hard-delete `@Scheduled`. **Phase 4**: 운영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)