### PR TITLE
feat: 그룹 빙고 탈퇴 회원 '탈퇴한 회원' 익명화 표시 — 탈퇴 Phase 2

### DIFF
--- a/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardFindApiTest.kt
+++ b/boot/gb-boot-web/src/test/kotlin/com/beside/groubing/domain/bingo/api/BingoBoardFindApiTest.kt
@@ -9,6 +9,7 @@ import com.beside.groubing.docs.requestParam
 import com.beside.groubing.docs.responseBody
 import com.beside.groubing.domain.bingo.application.BingoBoardFindService
 import com.beside.groubing.domain.bingo.domain.BingoBoardDetail
+import com.beside.groubing.domain.member.domain.Members
 import com.beside.groubing.extension.encodedAs
 import com.beside.groubing.extension.getHttpHeaderJwt
 import com.beside.groubing.domain.common.id.ObfuscationType
@@ -67,7 +68,7 @@ class BingoBoardFindApiTest(
         val encodedBingoBoardId = bingoBoardId.encodedAs(ObfuscationType.BINGO_BOARD)
         val bingoBoard = aEnglishStudyBingoBoard()
         val member = aMember(memberId).toDomain()
-        val otherMembers = (2L..5L).map { aMember(it).toDomain() }
+        val otherMembers = Members.of((2L..5L).map { aMember(it).toDomain() })
 
         every { bingoBoardFindService.findOne(memberId, bingoBoardId) } returns BingoBoardDetail(bingoBoard, member, otherMembers)
 

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardFindService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardFindService.kt
@@ -17,6 +17,7 @@ class BingoBoardFindService(
         bingoBoard.validateViewableBy(memberId)
         val viewer = memberQueryRepository.findActiveById(memberId)
         val otherMembers = memberQueryRepository.findAll(bingoBoard.otherActiveMemberIdsOf(memberId))
+            .map { it.anonymizeIfWithdrawn() }
         return BingoBoardDetail(bingoBoard, viewer, otherMembers)
     }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardFindService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardFindService.kt
@@ -2,6 +2,7 @@ package com.beside.groubing.domain.bingo.application
 
 import com.beside.groubing.domain.bingo.domain.BingoBoardDetail
 import com.beside.groubing.domain.bingo.domain.port.BingoBoardQueryRepository
+import com.beside.groubing.domain.member.domain.Members
 import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,8 +17,8 @@ class BingoBoardFindService(
         val bingoBoard = bingoBoardQueryRepository.findOne(boardId)
         bingoBoard.validateViewableBy(memberId)
         val viewer = memberQueryRepository.findActiveById(memberId)
-        val otherMembers = memberQueryRepository.findAll(bingoBoard.otherActiveMemberIdsOf(memberId))
-            .map { it.anonymizeIfWithdrawn() }
+        val otherMembers = Members.of(memberQueryRepository.findAll(bingoBoard.otherActiveMemberIdsOf(memberId)))
+            .anonymizeWithdrawn()
         return BingoBoardDetail(bingoBoard, viewer, otherMembers)
     }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoardDetail.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoardDetail.kt
@@ -1,9 +1,10 @@
 package com.beside.groubing.domain.bingo.domain
 
 import com.beside.groubing.domain.member.domain.Member
+import com.beside.groubing.domain.member.domain.Members
 
 data class BingoBoardDetail(
     val bingoBoard: BingoBoard,
     val viewer: Member,
-    val otherMembers: List<Member>
+    val otherMembers: Members
 )

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/feed/application/FeedListFindService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/feed/application/FeedListFindService.kt
@@ -41,7 +41,7 @@ class FeedListFindService(
 
         val titlesByMember = feedListQueryRepository.findCompletedFeedItems(completerIds)
             .groupBy({ it.memberId }, { it.title })
-        val members = memberQueryRepository.findAll(completerIds).sortedBy { it.id }
+        val members = memberQueryRepository.findAllActive(completerIds).sortedBy { it.id }
 
         return members.mapNotNull { member ->
             val titles = titlesByMember[member.id].orEmpty().shuffled().take(MAX_FEED_ITEMS)

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/feed/application/FriendFeedListFindService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/feed/application/FriendFeedListFindService.kt
@@ -24,7 +24,7 @@ class FriendFeedListFindService(
 
         val titlesByMember = feedListQueryRepository.findCompletedFeedItems(completerIds)
             .groupBy({ it.memberId }, { it.title })
-        val members = memberQueryRepository.findAll(completerIds).sortedBy { it.id }
+        val members = memberQueryRepository.findAllActive(completerIds).sortedBy { it.id }
 
         return members.mapNotNull { member ->
             val titles = titlesByMember[member.id].orEmpty().shuffled().take(MAX_FEED_ITEMS)

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/Member.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/Member.kt
@@ -31,4 +31,13 @@ data class Member(
     }
 
     fun hasNickname(): Boolean = nickname.isNotBlank()
+
+    fun isWithdrawn(): Boolean = deletedAt != null
+
+    fun anonymizeIfWithdrawn(): Member =
+        if (isWithdrawn()) copy(nickname = WITHDRAWN_NICKNAME, profileUrl = null) else this
+
+    companion object {
+        const val WITHDRAWN_NICKNAME = "탈퇴한 회원"
+    }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/Members.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/Members.kt
@@ -1,0 +1,12 @@
+package com.beside.groubing.domain.member.domain
+
+class Members private constructor(val data: List<Member>) : Iterable<Member> {
+
+    override fun iterator(): Iterator<Member> = data.iterator()
+
+    fun anonymizeWithdrawn(): Members = Members(data.map { it.anonymizeIfWithdrawn() })
+
+    companion object {
+        fun of(members: List<Member>): Members = Members(members)
+    }
+}

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberQueryRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberQueryRepository.kt
@@ -15,6 +15,8 @@ interface MemberQueryRepository {
 
     fun findAll(ids: Collection<Long>): List<Member>
 
+    fun findAllActive(ids: Collection<Long>): List<Member>
+
     fun existsByLoginId(loginId: String): Boolean
 
     fun existsByNickname(nickname: String): Boolean

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardFindServiceTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/application/BingoBoardFindServiceTest.kt
@@ -1,0 +1,68 @@
+package com.beside.groubing.domain.bingo.application
+
+import com.beside.groubing.domain.bingo.domain.BingoBoard
+import com.beside.groubing.domain.bingo.domain.port.BingoBoardQueryRepository
+import com.beside.groubing.domain.member.domain.Member
+import com.beside.groubing.domain.member.domain.MemberRole
+import com.beside.groubing.domain.member.domain.MemberType
+import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import java.time.LocalDateTime
+
+class BingoBoardFindServiceTest : BehaviorSpec({
+    val bingoBoardQueryRepository = mockk<BingoBoardQueryRepository>()
+    val memberQueryRepository = mockk<MemberQueryRepository>()
+    val bingoBoardFindService = BingoBoardFindService(bingoBoardQueryRepository, memberQueryRepository)
+
+    fun aMember(
+        id: Long,
+        nickname: String,
+        active: Boolean,
+        deletedAt: LocalDateTime?,
+        profileUrl: String?
+    ) = Member(
+        id = id,
+        loginId = "login$id",
+        password = "encoded",
+        nickname = nickname,
+        role = MemberRole.MEMBER,
+        memberType = MemberType.CLASSIC,
+        fcmToken = null,
+        notificationReceive = true,
+        active = active,
+        deletedAt = deletedAt,
+        profileUrl = profileUrl
+    )
+
+    Given("그룹 빙고에 탈퇴한 참여자와 활성 참여자가 함께 있을 때") {
+        val viewerId = 1L
+        val boardId = 10L
+        val viewer = aMember(viewerId, "조회자", active = true, deletedAt = null, profileUrl = "p1.png")
+        val activeOther = aMember(2L, "활성유저", active = true, deletedAt = null, profileUrl = "p2.png")
+        val withdrawnOther = aMember(3L, "탈퇴전닉", active = false, deletedAt = LocalDateTime.now(), profileUrl = "p3.png")
+
+        val bingoBoard = mockk<BingoBoard>()
+        every { bingoBoardQueryRepository.findOne(boardId) } returns bingoBoard
+        every { bingoBoard.validateViewableBy(viewerId) } just Runs
+        every { bingoBoard.otherActiveMemberIdsOf(viewerId) } returns listOf(2L, 3L)
+        every { memberQueryRepository.findActiveById(viewerId) } returns viewer
+        every { memberQueryRepository.findAll(listOf(2L, 3L)) } returns listOf(activeOther, withdrawnOther)
+
+        When("빙고 상세를 조회하면") {
+            val detail = bingoBoardFindService.findOne(viewerId, boardId)
+
+            Then("탈퇴한 참여자는 '탈퇴한 회원'으로 익명화되고 활성 참여자는 그대로 유지된다") {
+                val byId = detail.otherMembers.associateBy { it.id }
+                byId[2L]!!.nickname shouldBe "활성유저"
+                byId[2L]!!.profileUrl shouldBe "p2.png"
+                byId[3L]!!.nickname shouldBe "탈퇴한 회원"
+                byId[3L]!!.profileUrl shouldBe null
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/member/domain/MemberTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/member/domain/MemberTest.kt
@@ -5,21 +5,27 @@ import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
 
 class MemberTest : BehaviorSpec({
 
-    fun aMember(active: Boolean) = Member(
+    fun aMember(
+        active: Boolean = true,
+        deletedAt: LocalDateTime? = null,
+        nickname: String = "nickname",
+        profileUrl: String? = null
+    ) = Member(
         id = 1L,
         loginId = "groubing",
         password = "encoded",
-        nickname = "nickname",
+        nickname = nickname,
         role = MemberRole.MEMBER,
         memberType = MemberType.CLASSIC,
         fcmToken = null,
         notificationReceive = true,
         active = active,
-        deletedAt = null,
-        profileUrl = null
+        deletedAt = deletedAt,
+        profileUrl = profileUrl
     )
 
     Given("활성 상태의 회원이 주어졌을 때") {
@@ -40,6 +46,37 @@ class MemberTest : BehaviorSpec({
                 shouldThrow<MemberInputException> {
                     member.validateWithdrawable()
                 }.message shouldBe "이미 탈퇴한 회원입니다."
+            }
+        }
+    }
+
+    Given("탈퇴한 회원(deletedAt 존재)이 주어졌을 때") {
+        val member = aMember(
+            active = false,
+            deletedAt = LocalDateTime.now(),
+            nickname = "원래닉네임",
+            profileUrl = "https://image/profile.png"
+        )
+
+        When("anonymizeIfWithdrawn 을 호출하면") {
+            val anonymized = member.anonymizeIfWithdrawn()
+
+            Then("닉네임이 '탈퇴한 회원'으로 바뀌고 프로필이 제거된다") {
+                anonymized.nickname shouldBe "탈퇴한 회원"
+                anonymized.profileUrl shouldBe null
+            }
+        }
+    }
+
+    Given("활성 회원(deletedAt 없음)이 주어졌을 때") {
+        val member = aMember(nickname = "원래닉네임", profileUrl = "https://image/profile.png")
+
+        When("anonymizeIfWithdrawn 을 호출하면") {
+            val result = member.anonymizeIfWithdrawn()
+
+            Then("닉네임과 프로필이 그대로 유지된다") {
+                result.nickname shouldBe "원래닉네임"
+                result.profileUrl shouldBe "https://image/profile.png"
             }
         }
     }

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/member/domain/MembersTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/member/domain/MembersTest.kt
@@ -1,0 +1,45 @@
+package com.beside.groubing.domain.member.domain
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class MembersTest : BehaviorSpec({
+
+    fun aMember(
+        id: Long,
+        nickname: String,
+        active: Boolean,
+        deletedAt: LocalDateTime?,
+        profileUrl: String?
+    ) = Member(
+        id = id,
+        loginId = "login$id",
+        password = "encoded",
+        nickname = nickname,
+        role = MemberRole.MEMBER,
+        memberType = MemberType.CLASSIC,
+        fcmToken = null,
+        notificationReceive = true,
+        active = active,
+        deletedAt = deletedAt,
+        profileUrl = profileUrl
+    )
+
+    Given("탈퇴 회원과 활성 회원이 섞인 Members 가 주어졌을 때") {
+        val active = aMember(1L, "활성유저", active = true, deletedAt = null, profileUrl = "p1.png")
+        val withdrawn = aMember(2L, "탈퇴전닉", active = false, deletedAt = LocalDateTime.now(), profileUrl = "p2.png")
+        val members = Members.of(listOf(active, withdrawn))
+
+        When("anonymizeWithdrawn 을 호출하면") {
+            val anonymized = members.anonymizeWithdrawn().associateBy { it.id }
+
+            Then("탈퇴 회원만 '탈퇴한 회원'으로 익명화되고 활성 회원은 그대로 유지된다") {
+                anonymized[1L]!!.nickname shouldBe "활성유저"
+                anonymized[1L]!!.profileUrl shouldBe "p1.png"
+                anonymized[2L]!!.nickname shouldBe "탈퇴한 회원"
+                anonymized[2L]!!.profileUrl shouldBe null
+            }
+        }
+    }
+})

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapter.kt
@@ -73,6 +73,10 @@ class MemberRepositoryAdapter(
     }
 
     override fun findAll(ids: Collection<Long>): List<Member> {
+        return memberJpaRepository.findAllById(ids).map { it.toDomain() }
+    }
+
+    override fun findAllActive(ids: Collection<Long>): List<Member> {
         return memberJpaRepository.findAllByIdInAndActiveTrue(ids).map { it.toDomain() }
     }
 

--- a/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapterTest.kt
+++ b/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapterTest.kt
@@ -7,6 +7,7 @@ import com.beside.groubing.domain.member.exception.MemberInputException
 import com.beside.groubing.persistence.PersistenceTest
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.springframework.context.annotation.Import
 import java.time.LocalDateTime
@@ -68,5 +69,15 @@ class MemberRepositoryAdapterTest(
         shouldThrow<MemberInputException> {
             memberRepositoryAdapter.findActiveById(saved.id)
         }.message shouldBe "존재하지 않는 유저 입니다."
+    }
+
+    test("findAll 은 탈퇴한 회원도 포함하지만 findAllActive 는 활성 회원만 조회한다") {
+        val active = memberRepositoryAdapter.save(newMember(loginId = "act", nickname = "actNick"))
+        val withdrawn = memberRepositoryAdapter.save(newMember(loginId = "wd2", nickname = "wd2Nick"))
+        memberRepositoryAdapter.withdraw(withdrawn.id, LocalDateTime.now())
+
+        val ids = listOf(active.id, withdrawn.id)
+        memberRepositoryAdapter.findAll(ids).map { it.id } shouldContainExactlyInAnyOrder ids
+        memberRepositoryAdapter.findAllActive(ids).map { it.id } shouldBe listOf(active.id)
     }
 })


### PR DESCRIPTION
## 개요
회원 탈퇴 정책 **Phase 2** — 그룹 빙고 상세에서 탈퇴한 회원을 삭제하지 않고 **'탈퇴한 회원'으로 익명 보존·표시**한다. (Phase 1 #35: 즉시 soft-delete)

## 배경 / 문제
- 탈퇴(`Member.deletedAt`)는 빙고를 건드리지 않으므로, 탈퇴자는 `BingoMember.active=true`로 그룹 빙고에 그대로 남는다.
- 그런데 멤버 닉네임을 푸는 조회가 `...AndActiveTrue`(계정 활성) 필터를 타서, **탈퇴자가 빙고 상세에서 통째로 사라지던** 상태였다.
- `BingoMember.active`(빙고 나감/leave)와 `Member.active`(계정 탈퇴)는 별개 개념 — leave한 멤버는 계속 제외하되, 탈퇴자는 익명 표시해야 한다.

## 변경 사항
- **`Member.anonymizeIfWithdrawn()`** 도메인 메서드: `deletedAt` 있으면 `nickname='탈퇴한 회원'`, `profileUrl=null`.
- **포트 정직 분리**: `findAll`(탈퇴자 포함, 필터 없음) / `findAllActive`(활성만) — Phase 1의 `findById`/`findActiveById` 미러.
- **`BingoBoardFindService`**: 다른 멤버를 `findAll`로 조회 + 익명화 매핑. `otherActiveMemberIdsOf`는 유지(빙고에서 leave한 멤버는 여전히 제외).
- **피드(전체/친구)**: `findAllActive`로 전환해 탈퇴자 제외 현행 유지. (피드는 보존할 상호작용이 없어 익명 표시 대상 아님 — 댓글/리액션 엔티티 부재 확인)
- **응답 팩토리 무변경** (`nickname`/`profileUrl` 그대로 흘러감).

## 테스트
- `MemberTest`: `anonymizeIfWithdrawn` 탈퇴자 익명화 / 활성 회원 무변경.
- `MemberRepositoryAdapterTest`: `findAll`은 탈퇴자 포함, `findAllActive`는 활성만.
- `BingoBoardFindServiceTest`(신규): 그룹 빙고 상세에서 탈퇴 참여자 '탈퇴한 회원' 익명화 + 활성 참여자 유지.
- `./gradlew build` 그린.

## 범위 밖 (다음 단계)
- Phase 3: 1년 경과 hard-delete 스케줄 잡 (별도 오케스트레이션 컨텍스트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)