### PR TITLE
feat: 만료 회원 정리 스케줄 잡 + Member tombstone — 탈퇴 Phase 3a

### DIFF
--- a/boot/gb-boot-web/build.gradle.kts
+++ b/boot/gb-boot-web/build.gradle.kts
@@ -34,9 +34,6 @@ dependencies {
     implementation(project(":infrastructure:support:gb-crypto-core"))
     implementation(project(":infrastructure:support:gb-id-obfuscator"))
 
-    // Kotlin-Logging
-    implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
-
     // FCM
     implementation(project(":infrastructure:support:gb-fcm-sender"))
 

--- a/boot/gb-boot-web/build.gradle.kts
+++ b/boot/gb-boot-web/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
 
     // Config modules
     runtimeOnly(project(":config:gb-config-yaml-importer"))
-    runtimeOnly(project(":config:gb-config-logging"))
+    implementation(project(":config:gb-config-logging"))
 
     // AsciiDocs
     val asciidoctorExt: Configuration by configurations.creating

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/withdrawal/scheduler/ExpiredMemberCleanupScheduler.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/domain/withdrawal/scheduler/ExpiredMemberCleanupScheduler.kt
@@ -1,0 +1,15 @@
+package com.beside.groubing.domain.withdrawal.scheduler
+
+import com.beside.groubing.domain.withdrawal.application.ExpiredMemberCleanupService
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class ExpiredMemberCleanupScheduler(
+    private val expiredMemberCleanupService: ExpiredMemberCleanupService
+) {
+    @Scheduled(cron = "\${withdrawal.cleanup-cron:0 0 4 * * *}")
+    fun cleanupExpiredMembers() {
+        expiredMemberCleanupService.cleanupExpired()
+    }
+}

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/config/SchedulingConfig.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/config/SchedulingConfig.kt
@@ -1,0 +1,8 @@
+package com.beside.groubing.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+class SchedulingConfig

--- a/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/handler/GlobalExceptionHandler.kt
+++ b/boot/gb-boot-web/src/main/kotlin/com/beside/groubing/global/handler/GlobalExceptionHandler.kt
@@ -8,7 +8,7 @@ import com.beside.groubing.domain.common.file.exception.FileInfoInputException
 import com.beside.groubing.domain.common.id.exception.InvalidObfuscatedIdException
 import com.beside.groubing.global.response.ApiResponseCode
 import com.beside.groubing.global.response.error.ApiError
-import org.slf4j.LoggerFactory
+import mu.KotlinLogging
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -20,10 +20,10 @@ import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
+private val log = KotlinLogging.logger {}
+
 @RestControllerAdvice
 class GlobalExceptionHandler {
-
-    private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
 
     @ExceptionHandler(MissingRequestHeaderException::class)
     fun handle(e: MissingRequestHeaderException): ResponseEntity<ApiError> {
@@ -100,7 +100,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception::class)
     fun handleException(e: Exception): ResponseEntity<ApiError> {
-        log.error("handleException", e)
+        log.error(e) { "handleException" }
         val apiError = ApiError(ApiResponseCode.SERVER_ERROR, e)
         return ResponseEntity(apiError, HttpStatus.INTERNAL_SERVER_ERROR)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ subprojects {
     dependencies {
         "implementation"("org.jetbrains.kotlin:kotlin-reflect")
         "implementation"("org.jetbrains.kotlin:kotlin-stdlib")
+        "implementation"("io.github.microutils:kotlin-logging-jvm:3.0.5")
 
         "testImplementation"("org.springframework.boot:spring-boot-starter-test") {
             exclude(group = "org.junit.vintage", module = "junit-vintage-engine")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,6 @@ subprojects {
     dependencies {
         "implementation"("org.jetbrains.kotlin:kotlin-reflect")
         "implementation"("org.jetbrains.kotlin:kotlin-stdlib")
-        "implementation"("io.github.microutils:kotlin-logging-jvm:3.0.5")
 
         "testImplementation"("org.springframework.boot:spring-boot-starter-test") {
             exclude(group = "org.junit.vintage", module = "junit-vintage-engine")

--- a/config/gb-config-logging/build.gradle.kts
+++ b/config/gb-config-logging/build.gradle.kts
@@ -1,5 +1,11 @@
-// Logback 설정을 classpath에 제공하는 리소스 전용 모듈.
+// 로깅 모듈: logback 설정(logback.xml) + 로깅 파사드(kotlin-logging)를 프로젝트 전역에 제공한다.
+plugins {
+    `java-library`
+}
+
 dependencies {
+    // 로깅 파사드는 의존 모듈이 직접 호출하므로 api 로 노출(전이).
+    api("io.github.microutils:kotlin-logging-jvm:3.0.5")
     implementation("org.springframework.boot:spring-boot-starter")
 }
 

--- a/domain/gb-domain-core/build.gradle.kts
+++ b/domain/gb-domain-core/build.gradle.kts
@@ -9,6 +9,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework:spring-tx")
 
+    // 로깅 모듈(kotlin-logging 파사드 + logback 설정)
+    implementation(project(":config:gb-config-logging"))
+
     // testFixtures: 도메인 픽스처에서 Arb 사용
     testFixturesImplementation("io.kotest:kotest-property-jvm:5.5.5")
 

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/auth/domain/port/SocialInfoRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/auth/domain/port/SocialInfoRepository.kt
@@ -7,4 +7,6 @@ interface SocialInfoRepository {
     fun save(socialInfo: SocialInfo): SocialInfo
 
     fun findBySocialIdAndSocialTypeOrNull(socialId: String, socialType: SocialType): SocialInfo?
+
+    fun deleteAllByMemberId(memberId: Long)
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/blockedmember/domain/port/BlockedMemberRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/blockedmember/domain/port/BlockedMemberRepository.kt
@@ -10,6 +10,8 @@ interface BlockedMemberRepository {
 
     fun delete(blockedMember: BlockedMember)
 
+    fun deleteAllOf(memberId: Long)
+
     fun exists(requesterId: Long, targetMemberId: Long): Boolean
 
     fun findAll(requesterId: Long): List<BlockedMemberTarget>

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/friend/domain/port/FriendCommandRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/friend/domain/port/FriendCommandRepository.kt
@@ -8,4 +8,6 @@ interface FriendCommandRepository {
     fun update(friend: Friend): Friend
 
     fun deleteAllBetween(memberIdA: Long, memberIdB: Long)
+
+    fun deleteAllOf(memberId: Long)
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberCommandRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberCommandRepository.kt
@@ -12,6 +12,8 @@ interface MemberCommandRepository {
 
     fun withdraw(memberId: Long, now: LocalDateTime = LocalDateTime.now())
 
+    fun tombstone(memberId: Long, now: LocalDateTime = LocalDateTime.now()): FileInfo?
+
     fun editProfileOrNull(memberId: Long, newProfile: FileInfo): FileInfo?
 
     fun deleteProfileOrNull(memberId: Long): FileInfo?

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberQueryRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberQueryRepository.kt
@@ -1,9 +1,12 @@
 package com.beside.groubing.domain.member.domain.port
 
 import com.beside.groubing.domain.member.domain.Member
+import java.time.LocalDateTime
 
 interface MemberQueryRepository {
     fun findById(id: Long): Member
+
+    fun findExpiredMemberIds(threshold: LocalDateTime): List<Long>
 
     fun findActiveById(id: Long): Member
 

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/notification/domain/port/NotificationRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/notification/domain/port/NotificationRepository.kt
@@ -4,4 +4,6 @@ import com.beside.groubing.domain.notification.domain.Notification
 
 interface NotificationRepository {
     fun save(notification: Notification): Notification
+
+    fun deleteAllByMemberId(memberId: Long)
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupService.kt
@@ -1,0 +1,24 @@
+package com.beside.groubing.domain.withdrawal.application
+
+import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class ExpiredMemberCleanupService(
+    private val memberQueryRepository: MemberQueryRepository,
+    private val memberCleanupExecutor: MemberCleanupExecutor,
+    @Value("\${withdrawal.grace-days:365}") private val graceDays: Long
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun cleanupExpired(now: LocalDateTime = LocalDateTime.now()) {
+        val threshold = now.minusDays(graceDays)
+        memberQueryRepository.findExpiredMemberIds(threshold).forEach { memberId ->
+            runCatching { memberCleanupExecutor.cleanup(memberId) }
+                .onFailure { log.error("만료 회원 정리 실패. memberId=$memberId", it) }
+        }
+    }
+}

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupService.kt
@@ -1,10 +1,12 @@
 package com.beside.groubing.domain.withdrawal.application
 
 import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
-import org.slf4j.LoggerFactory
+import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
+
+private val log = KotlinLogging.logger {}
 
 @Service
 class ExpiredMemberCleanupService(
@@ -12,13 +14,11 @@ class ExpiredMemberCleanupService(
     private val memberCleanupExecutor: MemberCleanupExecutor,
     @Value("\${withdrawal.grace-days:365}") private val graceDays: Long
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
-
     fun cleanupExpired(now: LocalDateTime = LocalDateTime.now()) {
         val threshold = now.minusDays(graceDays)
         memberQueryRepository.findExpiredMemberIds(threshold).forEach { memberId ->
             runCatching { memberCleanupExecutor.cleanup(memberId) }
-                .onFailure { log.error("만료 회원 정리 실패. memberId=$memberId", it) }
+                .onFailure { log.error(it) { "만료 회원 정리 실패. memberId=$memberId" } }
         }
     }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleanupExecutor.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleanupExecutor.kt
@@ -1,0 +1,28 @@
+package com.beside.groubing.domain.withdrawal.application
+
+import com.beside.groubing.domain.auth.domain.port.SocialInfoRepository
+import com.beside.groubing.domain.blockedmember.domain.port.BlockedMemberRepository
+import com.beside.groubing.domain.common.file.application.FileStorage
+import com.beside.groubing.domain.friend.domain.port.FriendCommandRepository
+import com.beside.groubing.domain.member.domain.port.MemberCommandRepository
+import com.beside.groubing.domain.notification.domain.port.NotificationRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class MemberCleanupExecutor(
+    private val notificationRepository: NotificationRepository,
+    private val friendCommandRepository: FriendCommandRepository,
+    private val blockedMemberRepository: BlockedMemberRepository,
+    private val socialInfoRepository: SocialInfoRepository,
+    private val memberCommandRepository: MemberCommandRepository
+) {
+    @Transactional
+    fun cleanup(memberId: Long) {
+        notificationRepository.deleteAllByMemberId(memberId)
+        friendCommandRepository.deleteAllOf(memberId)
+        blockedMemberRepository.deleteAllOf(memberId)
+        socialInfoRepository.deleteAllByMemberId(memberId)
+        memberCommandRepository.tombstone(memberId)?.let { FileStorage.delete(it) }
+    }
+}

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupServiceTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupServiceTest.kt
@@ -1,0 +1,47 @@
+package com.beside.groubing.domain.withdrawal.application
+
+import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+
+class ExpiredMemberCleanupServiceTest : BehaviorSpec({
+    val memberQueryRepository = mockk<MemberQueryRepository>()
+    val memberCleanupExecutor = mockk<MemberCleanupExecutor>()
+    val cleanupService = ExpiredMemberCleanupService(memberQueryRepository, memberCleanupExecutor, graceDays = 365)
+
+    Given("만료 회원 3명 중 1명 정리가 실패할 때") {
+        val now = LocalDateTime.of(2026, 1, 1, 0, 0)
+        every { memberQueryRepository.findExpiredMemberIds(any()) } returns listOf(1L, 2L, 3L)
+        every { memberCleanupExecutor.cleanup(1L) } just Runs
+        every { memberCleanupExecutor.cleanup(2L) } throws RuntimeException("boom")
+        every { memberCleanupExecutor.cleanup(3L) } just Runs
+
+        When("cleanupExpired 를 호출하면") {
+            cleanupService.cleanupExpired(now)
+
+            Then("한 명의 실패가 격리되고 나머지 회원도 모두 정리가 시도된다") {
+                verify(exactly = 1) { memberCleanupExecutor.cleanup(1L) }
+                verify(exactly = 1) { memberCleanupExecutor.cleanup(2L) }
+                verify(exactly = 1) { memberCleanupExecutor.cleanup(3L) }
+            }
+        }
+    }
+
+    Given("그레이스 기간(365일) 회원이 주어졌을 때") {
+        val now = LocalDateTime.of(2026, 1, 1, 0, 0)
+        every { memberQueryRepository.findExpiredMemberIds(any()) } returns emptyList()
+
+        When("cleanupExpired(now) 를 호출하면") {
+            cleanupService.cleanupExpired(now)
+
+            Then("now 에서 graceDays 를 뺀 시각을 만료 기준으로 스캔한다") {
+                verify(exactly = 1) { memberQueryRepository.findExpiredMemberIds(now.minusDays(365)) }
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleanupExecutorTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleanupExecutorTest.kt
@@ -1,0 +1,69 @@
+package com.beside.groubing.domain.withdrawal.application
+
+import com.beside.groubing.domain.auth.domain.port.SocialInfoRepository
+import com.beside.groubing.domain.blockedmember.domain.port.BlockedMemberRepository
+import com.beside.groubing.domain.common.file.application.FileStorage
+import com.beside.groubing.domain.common.file.domain.FileInfo
+import com.beside.groubing.domain.friend.domain.port.FriendCommandRepository
+import com.beside.groubing.domain.member.domain.port.MemberCommandRepository
+import com.beside.groubing.domain.notification.domain.port.NotificationRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+
+class MemberCleanupExecutorTest : BehaviorSpec({
+    val notificationRepository = mockk<NotificationRepository>(relaxed = true)
+    val friendCommandRepository = mockk<FriendCommandRepository>(relaxed = true)
+    val blockedMemberRepository = mockk<BlockedMemberRepository>(relaxed = true)
+    val socialInfoRepository = mockk<SocialInfoRepository>(relaxed = true)
+    val memberCommandRepository = mockk<MemberCommandRepository>()
+    val executor = MemberCleanupExecutor(
+        notificationRepository,
+        friendCommandRepository,
+        blockedMemberRepository,
+        socialInfoRepository,
+        memberCommandRepository
+    )
+
+    beforeSpec { mockkObject(FileStorage.Companion) }
+    afterSpec { unmockkObject(FileStorage.Companion) }
+
+    Given("프로필이 있는 만료 회원이 주어졌을 때") {
+        val memberId = 7L
+        val previousProfile = mockk<FileInfo>()
+        every { memberCommandRepository.tombstone(memberId, any()) } returns previousProfile
+        every { FileStorage.delete(previousProfile) } just Runs
+
+        When("cleanup 을 호출하면") {
+            executor.cleanup(memberId)
+
+            Then("연관 데이터 삭제 + tombstone + 프로필 물리파일 삭제가 수행된다") {
+                verify(exactly = 1) { notificationRepository.deleteAllByMemberId(memberId) }
+                verify(exactly = 1) { friendCommandRepository.deleteAllOf(memberId) }
+                verify(exactly = 1) { blockedMemberRepository.deleteAllOf(memberId) }
+                verify(exactly = 1) { socialInfoRepository.deleteAllByMemberId(memberId) }
+                verify(exactly = 1) { memberCommandRepository.tombstone(memberId, any()) }
+                verify(exactly = 1) { FileStorage.delete(previousProfile) }
+            }
+        }
+    }
+
+    Given("프로필이 없는 만료 회원이 주어졌을 때") {
+        val memberId = 8L
+        every { memberCommandRepository.tombstone(memberId, any()) } returns null
+
+        When("cleanup 을 호출하면") {
+            executor.cleanup(memberId)
+
+            Then("물리파일 삭제는 호출되지 않는다") {
+                verify(exactly = 1) { memberCommandRepository.tombstone(memberId, any()) }
+                verify(exactly = 0) { FileStorage.delete(any()) }
+            }
+        }
+    }
+})

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/auth/repository/SocialInfoJpaRepository.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/auth/repository/SocialInfoJpaRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface SocialInfoJpaRepository : JpaRepository<SocialInfoEntity, Long> {
     fun findBySocialIdAndSocialType(socialId: String, socialType: SocialType): SocialInfoEntity?
+
+    fun deleteByMemberId(memberId: Long)
 }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/auth/repository/SocialInfoRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/auth/repository/SocialInfoRepositoryAdapter.kt
@@ -17,4 +17,8 @@ class SocialInfoRepositoryAdapter(
     override fun findBySocialIdAndSocialTypeOrNull(socialId: String, socialType: SocialType): SocialInfo? {
         return socialInfoJpaRepository.findBySocialIdAndSocialType(socialId, socialType)?.toDomain()
     }
+
+    override fun deleteAllByMemberId(memberId: Long) {
+        socialInfoJpaRepository.deleteByMemberId(memberId)
+    }
 }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/blockedmember/repository/BlockedMemberJpaRepository.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/blockedmember/repository/BlockedMemberJpaRepository.kt
@@ -7,4 +7,6 @@ interface BlockedMemberJpaRepository : JpaRepository<BlockedMemberEntity, Long> 
     fun existsByRequesterIdAndTargetMemberId(requesterId: Long, targetMemberId: Long): Boolean
 
     fun findByRequesterIdAndTargetMemberId(requesterId: Long, targetMemberId: Long): BlockedMemberEntity?
+
+    fun deleteByRequesterIdOrTargetMemberId(requesterId: Long, targetMemberId: Long)
 }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/blockedmember/repository/BlockedMemberRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/blockedmember/repository/BlockedMemberRepositoryAdapter.kt
@@ -26,6 +26,10 @@ class BlockedMemberRepositoryAdapter(
         blockedMemberJpaRepository.deleteById(blockedMember.id)
     }
 
+    override fun deleteAllOf(memberId: Long) {
+        blockedMemberJpaRepository.deleteByRequesterIdOrTargetMemberId(memberId, memberId)
+    }
+
     override fun exists(requesterId: Long, targetMemberId: Long): Boolean {
         return blockedMemberJpaRepository.existsByRequesterIdAndTargetMemberId(requesterId, targetMemberId)
     }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/friend/repository/FriendJpaRepository.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/friend/repository/FriendJpaRepository.kt
@@ -17,4 +17,6 @@ interface FriendJpaRepository : JpaRepository<FriendEntity, Long> {
         @Param("memberIdA") memberIdA: Long,
         @Param("memberIdB") memberIdB: Long
     ): List<FriendEntity>
+
+    fun deleteByInviterIdOrInviteeId(inviterId: Long, inviteeId: Long)
 }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/friend/repository/FriendRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/friend/repository/FriendRepositoryAdapter.kt
@@ -31,6 +31,10 @@ class FriendRepositoryAdapter(
         if (entities.isNotEmpty()) friendJpaRepository.deleteAll(entities)
     }
 
+    override fun deleteAllOf(memberId: Long) {
+        friendJpaRepository.deleteByInviterIdOrInviteeId(memberId, memberId)
+    }
+
     override fun findOne(id: Long): Friend {
         return findEntityById(id).toDomain()
     }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/entity/MemberEntity.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/entity/MemberEntity.kt
@@ -28,8 +28,7 @@ class MemberEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 
-    @Column(name = "LOGIN_ID", unique = true)
-    val loginId: String?,
+    loginId: String?,
 
     password: String,
 
@@ -42,6 +41,10 @@ class MemberEntity(
     @Enumerated(EnumType.STRING)
     val memberType: MemberType
 ) : BaseEntity() {
+    @Column(name = "LOGIN_ID", unique = true)
+    var loginId: String? = loginId
+        private set
+
     var password: String = password
         private set
 
@@ -62,6 +65,10 @@ class MemberEntity(
     var deletedAt: LocalDateTime? = null
         private set
 
+    @Column(name = "CLEANED_AT")
+    var cleanedAt: LocalDateTime? = null
+        private set
+
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumn(name = "PROFILE_ID")
     var profile: FileInfoEntity? = null
@@ -77,6 +84,16 @@ class MemberEntity(
     fun withdraw(now: LocalDateTime) {
         this.active = false
         this.deletedAt = now
+    }
+
+    fun tombstone(now: LocalDateTime) {
+        this.loginId = null
+        this.password = ""
+        this.nickname = "탈퇴회원_$id"
+        this.fcmToken = null
+        this.notificationReceive = false
+        this.profile = null
+        this.cleanedAt = now
     }
 
     fun editProfile(profile: FileInfoEntity) {

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberJpaRepository.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberJpaRepository.kt
@@ -3,9 +3,15 @@ package com.beside.groubing.domain.member.repository
 import com.beside.groubing.domain.member.entity.MemberEntity
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
 
 interface MemberJpaRepository : JpaRepository<MemberEntity, Long> {
     fun findByIdAndActiveTrue(id: Long): MemberEntity?
+
+    @Query("select m.id from MemberEntity m where m.deletedAt <= :threshold and m.cleanedAt is null")
+    fun findExpiredMemberIds(@Param("threshold") threshold: LocalDateTime): List<Long>
 
     fun findByLoginIdAndActiveTrue(loginId: String): MemberEntity?
 

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapter.kt
@@ -35,6 +35,13 @@ class MemberRepositoryAdapter(
         findActiveEntityById(memberId).withdraw(now)
     }
 
+    override fun tombstone(memberId: Long, now: LocalDateTime): FileInfo? {
+        val entity = findEntityById(memberId)
+        val previousProfile = entity.profile?.toDomain()
+        entity.tombstone(now)
+        return previousProfile
+    }
+
     override fun editProfileOrNull(memberId: Long, newProfile: FileInfo): FileInfo? {
         val entity = findActiveEntityById(memberId)
         val previous = entity.profile?.toDomain()
@@ -51,6 +58,10 @@ class MemberRepositoryAdapter(
 
     override fun findById(id: Long): Member {
         return findEntityById(id).toDomain()
+    }
+
+    override fun findExpiredMemberIds(threshold: LocalDateTime): List<Long> {
+        return memberJpaRepository.findExpiredMemberIds(threshold)
     }
 
     override fun findActiveById(id: Long): Member {

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/notification/repository/NotificationJpaRepository.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/notification/repository/NotificationJpaRepository.kt
@@ -11,4 +11,6 @@ interface NotificationJpaRepository : JpaRepository<NotificationEntity, Long> {
         memberId: Long,
         pageable: Pageable
     ): Page<NotificationEntity>
+
+    fun deleteByMemberId(memberId: Long)
 }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/notification/repository/NotificationRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/notification/repository/NotificationRepositoryAdapter.kt
@@ -17,6 +17,10 @@ class NotificationRepositoryAdapter(
         return notificationJpaRepository.save(NotificationEntity.from(notification)).toDomain()
     }
 
+    override fun deleteAllByMemberId(memberId: Long) {
+        notificationJpaRepository.deleteByMemberId(memberId)
+    }
+
     override fun findRecentOf(bingoBoardIds: List<Long>, myMemberId: Long): List<NotificationItem> {
         return notificationFindDao.findNotifications(bingoBoardIds, myMemberId)
             .map {

--- a/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapterTest.kt
+++ b/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapterTest.kt
@@ -7,8 +7,11 @@ import com.beside.groubing.domain.member.exception.MemberInputException
 import com.beside.groubing.persistence.PersistenceTest
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.springframework.context.annotation.Import
 import java.time.LocalDateTime
 
@@ -79,5 +82,35 @@ class MemberRepositoryAdapterTest(
         val ids = listOf(active.id, withdrawn.id)
         memberRepositoryAdapter.findAll(ids).map { it.id } shouldContainExactlyInAnyOrder ids
         memberRepositoryAdapter.findAllActive(ids).map { it.id } shouldBe listOf(active.id)
+    }
+
+    test("tombstone 하면 식별정보가 제거되고 cleanedAt 이 기록된다") {
+        val saved = memberRepositoryAdapter.save(newMember(loginId = "ts", nickname = "tsNick"))
+        memberRepositoryAdapter.withdraw(saved.id, LocalDateTime.now())
+
+        memberRepositoryAdapter.tombstone(saved.id, LocalDateTime.now())
+
+        val entity = memberJpaRepository.findById(saved.id).orElseThrow()
+        entity.loginId shouldBe null
+        entity.nickname shouldBe "탈퇴회원_${saved.id}"
+        entity.password shouldBe ""
+        entity.fcmToken shouldBe null
+        entity.cleanedAt shouldNotBe null
+    }
+
+    test("findExpiredMemberIds 는 기준 이전 탈퇴 + 미정리(cleanedAt null) 회원만 반환한다") {
+        val expired = memberRepositoryAdapter.save(newMember(loginId = "exp", nickname = "expNick"))
+        val recent = memberRepositoryAdapter.save(newMember(loginId = "rec", nickname = "recNick"))
+        val cleaned = memberRepositoryAdapter.save(newMember(loginId = "cln", nickname = "clnNick"))
+        memberRepositoryAdapter.withdraw(expired.id, LocalDateTime.now().minusDays(400))
+        memberRepositoryAdapter.withdraw(recent.id, LocalDateTime.now().minusDays(10))
+        memberRepositoryAdapter.withdraw(cleaned.id, LocalDateTime.now().minusDays(400))
+        memberRepositoryAdapter.tombstone(cleaned.id, LocalDateTime.now())
+
+        val result = memberRepositoryAdapter.findExpiredMemberIds(LocalDateTime.now().minusDays(365))
+
+        result shouldContain expired.id
+        result shouldNotContain recent.id
+        result shouldNotContain cleaned.id
     }
 })


### PR DESCRIPTION
## 개요
회원 탈퇴 정책 **Phase 3a** — 1년 경과(`deletedAt`) 탈퇴 회원을 데일리 스케줄로 정리하는 골격. (Phase 1 #35 soft-delete, Phase 2 #36 빙고 익명표시에 이어짐)

## 결정 (사용자 확정)
- Member 처리 = **조건부**(그룹 빙고 참여=tombstone, 단독·미참여=완전삭제) — ⚠️ 완전삭제하면 Phase 2 익명표시(`findAll`로 Member 조회)가 깨지므로 그룹 참여자는 tombstone 강제. **3a는 무조건 tombstone**, 조건부 완전삭제는 3b.
- 유예 중 복구 **미제공**, 리더 탈퇴 시 **이양**(3b).

## 아키텍처
cleanup은 `member`에 두지 않음(member=hub → 패키지 사이클). 신규 `domain/withdrawal/` 오케스트레이션이 각 도메인 포트를 **단방향** 의존.

## 변경 사항
- **스케줄러(boot-web, driving adapter)**: `@EnableScheduling`(SchedulingConfig) + `ExpiredMemberCleanupScheduler`(데일리 cron, 기본 04:00).
- **오케스트레이션(gb-domain-core/withdrawal)**: `ExpiredMemberCleanupService`(스캔+루프+**회원별 실패 격리**) / `MemberCleanupExecutor`(회원별 `@Transactional` — self-invocation 회피 위해 분리).
- **만료 스캔**: `MemberQueryRepository.findExpiredMemberIds`(`deletedAt<=threshold AND cleanedAt IS NULL`, active 필터 없음).
- **Member tombstone**: 식별정보 제거(loginId=null·password=""·nickname="탈퇴회원_id"·fcm=null·profile FK=null) + `cleanedAt` 마커 신규 컬럼. `deletedAt` 유지(Phase 2 익명화가 계속 읽음). nickname unique 제약 회피 위해 id 접미사. (loginId를 var로 전환)
- **도메인별 hard-delete 포트 추가**: Notification(memberId) / Friend(양방향) / BlockedMember(양방향) / SocialInfo + 프로필 **물리파일**(`FileStorage.delete`).
- **설정 외부화**: `withdrawal.grace-days`(기본 365), `withdrawal.cleanup-cron`(기본 04:00).

## 테스트
- `ExpiredMemberCleanupServiceTest`(MockK): 회원별 실패 격리, threshold = now−graceDays.
- `MemberCleanupExecutorTest`(MockK): 연관삭제+tombstone+물리파일 삭제, 프로필 없으면 파일삭제 생략.
- `MemberRepositoryAdapterTest`(persistence): tombstone PII 제거+cleanedAt, findExpiredMemberIds(기준이전+미정리만).
- `./gradlew build` 그린.

## 범위 밖 (Phase 3b)
- Bingo 정리: 단독보드 hard-delete, 그룹 보드 **리더 이양**.
- **조건부 Member 완전삭제**: 그룹 빙고 미참여자 → 완전삭제, 참여자 → tombstone 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)