### PR TITLE
feat: 빙고 정리·리더 이양·조건부 회원 완전삭제 — 탈퇴 Phase 3b

### DIFF
--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoard.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoBoard.kt
@@ -74,6 +74,8 @@ class BingoBoard private constructor(
 
     fun isLeader(memberId: Long): Boolean = bingoMembers.isLeaderOf(memberId)
 
+    fun electNextLeader(livingMemberIds: Collection<Long>): Long = bingoMembers.electNextLeader(livingMemberIds)
+
     fun validateAuthority(memberId: Long) = bingoMembers.validateLeaderOf(memberId, id)
 
     fun updateBingoItem(memberId: Long, bingoItemId: Long, title: String, subTitle: String?): BingoItem {

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoMembers.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/BingoMembers.kt
@@ -20,6 +20,11 @@ class BingoMembers private constructor(val data: MutableList<BingoMember>) : Ite
     fun isLeaderOf(memberId: Long): Boolean =
         data.any { it.memberId == memberId && it.isLeader() }
 
+    fun electNextLeader(livingMemberIds: Collection<Long>): Long =
+        data.filter { it.active && it.memberId in livingMemberIds }
+            .minOfOrNull { it.memberId }
+            ?: throw BingoIllegalStateException("리더를 이양할 살아있는 멤버가 없습니다.")
+
     fun findOf(memberId: Long, bingoBoardId: Long): BingoMember =
         data.find { it.memberId == memberId }
             ?: throw BingoInputException(

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardCommandRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/bingo/domain/port/BingoBoardCommandRepository.kt
@@ -21,4 +21,8 @@ interface BingoBoardCommandRepository {
     fun updateOpen(bingoBoardId: Long, open: Boolean)
 
     fun deactivateBingoMember(bingoBoardId: Long, memberId: Long)
+
+    fun changeLeader(bingoBoardId: Long, newLeaderId: Long)
+
+    fun hardDelete(bingoBoardId: Long)
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberCommandRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/member/domain/port/MemberCommandRepository.kt
@@ -14,6 +14,8 @@ interface MemberCommandRepository {
 
     fun tombstone(memberId: Long, now: LocalDateTime = LocalDateTime.now()): FileInfo?
 
+    fun hardDelete(memberId: Long): FileInfo?
+
     fun editProfileOrNull(memberId: Long, newProfile: FileInfo): FileInfo?
 
     fun deleteProfileOrNull(memberId: Long): FileInfo?

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/notification/domain/port/NotificationRepository.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/notification/domain/port/NotificationRepository.kt
@@ -6,4 +6,6 @@ interface NotificationRepository {
     fun save(notification: Notification): Notification
 
     fun deleteAllByMemberId(memberId: Long)
+
+    fun deleteAllByBingoBoardId(bingoBoardId: Long)
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupService.kt
@@ -1,8 +1,8 @@
 package com.beside.groubing.domain.withdrawal.application
 
 import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
+import com.beside.groubing.domain.withdrawal.domain.WithdrawalGracePeriod
 import mu.KotlinLogging
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
@@ -12,13 +12,13 @@ private val log = KotlinLogging.logger {}
 class ExpiredMemberCleanupService(
     private val memberQueryRepository: MemberQueryRepository,
     private val memberCleaner: MemberCleaner,
-    @Value("\${withdrawal.grace-days:365}") private val graceDays: Long
+    private val gracePeriod: WithdrawalGracePeriod
 ) {
     fun cleanupExpired(now: LocalDateTime = LocalDateTime.now()) {
-        val threshold = now.minusDays(graceDays)
-        memberQueryRepository.findExpiredMemberIds(threshold).forEach { memberId ->
-            runCatching { memberCleaner.cleanup(memberId) }
-                .onFailure { log.error(it) { "만료 회원 정리 실패. memberId=$memberId" } }
-        }
+        memberQueryRepository.findExpiredMemberIds(gracePeriod.calculateExpirationThreshold(now))
+            .forEach { memberId ->
+                runCatching { memberCleaner.cleanup(memberId) }
+                    .onFailure { log.error(it) { "만료 회원 정리 실패. memberId=$memberId" } }
+            }
     }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupService.kt
@@ -11,13 +11,13 @@ private val log = KotlinLogging.logger {}
 @Service
 class ExpiredMemberCleanupService(
     private val memberQueryRepository: MemberQueryRepository,
-    private val memberCleanupExecutor: MemberCleanupExecutor,
+    private val memberCleaner: MemberCleaner,
     @Value("\${withdrawal.grace-days:365}") private val graceDays: Long
 ) {
     fun cleanupExpired(now: LocalDateTime = LocalDateTime.now()) {
         val threshold = now.minusDays(graceDays)
         memberQueryRepository.findExpiredMemberIds(threshold).forEach { memberId ->
-            runCatching { memberCleanupExecutor.cleanup(memberId) }
+            runCatching { memberCleaner.cleanup(memberId) }
                 .onFailure { log.error(it) { "만료 회원 정리 실패. memberId=$memberId" } }
         }
     }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupService.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupService.kt
@@ -11,11 +11,10 @@ private val log = KotlinLogging.logger {}
 @Service
 class ExpiredMemberCleanupService(
     private val memberQueryRepository: MemberQueryRepository,
-    private val memberCleaner: MemberCleaner,
-    private val gracePeriod: WithdrawalGracePeriod
+    private val memberCleaner: MemberCleaner
 ) {
     fun cleanupExpired(now: LocalDateTime = LocalDateTime.now()) {
-        memberQueryRepository.findExpiredMemberIds(gracePeriod.calculateExpirationThreshold(now))
+        memberQueryRepository.findExpiredMemberIds(WithdrawalGracePeriod.calculateExpirationThreshold(now))
             .forEach { memberId ->
                 runCatching { memberCleaner.cleanup(memberId) }
                     .onFailure { log.error(it) { "만료 회원 정리 실패. memberId=$memberId" } }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleaner.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleaner.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 @Component
-class MemberCleanupExecutor(
+class MemberCleaner(
     private val notificationRepository: NotificationRepository,
     private val friendCommandRepository: FriendCommandRepository,
     private val blockedMemberRepository: BlockedMemberRepository,

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleanupExecutor.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleanupExecutor.kt
@@ -15,6 +15,7 @@ class MemberCleanupExecutor(
     private val friendCommandRepository: FriendCommandRepository,
     private val blockedMemberRepository: BlockedMemberRepository,
     private val socialInfoRepository: SocialInfoRepository,
+    private val withdrawnMemberBingoCleaner: WithdrawnMemberBingoCleaner,
     private val memberCommandRepository: MemberCommandRepository
 ) {
     @Transactional
@@ -23,6 +24,14 @@ class MemberCleanupExecutor(
         friendCommandRepository.deleteAllOf(memberId)
         blockedMemberRepository.deleteAllOf(memberId)
         socialInfoRepository.deleteAllByMemberId(memberId)
-        memberCommandRepository.tombstone(memberId)?.let { FileStorage.delete(it) }
+        val remainsInGroupBingo = withdrawnMemberBingoCleaner.cleanUpBoardsOf(memberId)
+        removeMember(memberId, remainsInGroupBingo)
+    }
+
+    private fun removeMember(memberId: Long, remainsInGroupBingo: Boolean) {
+        val previousProfile =
+            if (remainsInGroupBingo) memberCommandRepository.tombstone(memberId)
+            else memberCommandRepository.hardDelete(memberId)
+        previousProfile?.let { FileStorage.delete(it) }
     }
 }

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/WithdrawnMemberBingoCleaner.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/WithdrawnMemberBingoCleaner.kt
@@ -22,26 +22,29 @@ class WithdrawnMemberBingoCleaner(
      * @return 탈퇴 회원이 살아남은 그룹 빙고에 여전히 참여자로 남아있으면 true(= tombstone 필요).
      */
     fun cleanUpBoardsOf(memberId: Long): Boolean {
-        return bingoBoardQueryRepository.findAllOf(memberId)
-            .map { cleanUpBoard(it, memberId) }
+        val boards = bingoBoardQueryRepository.findAllOf(memberId)
+        val livingMemberIds = findLivingMemberIds(boards, memberId)
+        return boards
+            .map { cleanUpBoard(it, memberId, livingMemberIds) }
             .any { it }
     }
 
-    private fun cleanUpBoard(board: BingoBoard, memberId: Long): Boolean {
-        val livingOtherIds = livingOtherMemberIds(board, memberId)
+    private fun findLivingMemberIds(boards: List<BingoBoard>, memberId: Long): Set<Long> {
+        val candidateIds = boards.flatMap { it.otherActiveMemberIdsOf(memberId) }.distinct()
+        if (candidateIds.isEmpty()) return emptySet()
+        return memberQueryRepository.findAllActive(candidateIds).map { it.id }.toSet()
+    }
+
+    private fun cleanUpBoard(board: BingoBoard, memberId: Long, livingMemberIds: Set<Long>): Boolean {
+        val livingOtherIds = board.otherActiveMemberIdsOf(memberId).filter { it in livingMemberIds }
         if (livingOtherIds.isEmpty()) {
             deleteBoard(board.id)
             return false
         }
         if (board.isLeader(memberId)) {
-            bingoBoardCommandRepository.changeLeader(board.id, livingOtherIds.min())
+            bingoBoardCommandRepository.changeLeader(board.id, board.electNextLeader(livingOtherIds))
         }
         return true
-    }
-
-    private fun livingOtherMemberIds(board: BingoBoard, memberId: Long): List<Long> {
-        val otherActiveIds = board.otherActiveMemberIdsOf(memberId)
-        return memberQueryRepository.findAllActive(otherActiveIds).map { it.id }
     }
 
     private fun deleteBoard(bingoBoardId: Long) {

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/WithdrawnMemberBingoCleaner.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/application/WithdrawnMemberBingoCleaner.kt
@@ -1,0 +1,51 @@
+package com.beside.groubing.domain.withdrawal.application
+
+import com.beside.groubing.domain.bingo.domain.BingoBoard
+import com.beside.groubing.domain.bingo.domain.port.BingoBoardCommandRepository
+import com.beside.groubing.domain.bingo.domain.port.BingoBoardQueryRepository
+import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
+import com.beside.groubing.domain.notification.domain.port.NotificationRepository
+import org.springframework.stereotype.Component
+
+@Component
+class WithdrawnMemberBingoCleaner(
+    private val bingoBoardQueryRepository: BingoBoardQueryRepository,
+    private val bingoBoardCommandRepository: BingoBoardCommandRepository,
+    private val notificationRepository: NotificationRepository,
+    private val memberQueryRepository: MemberQueryRepository
+) {
+    /**
+     * 탈퇴 회원이 속한 빙고 보드를 정리한다.
+     * - 살아있는 동료가 없는 보드(단독 또는 동료 전원 탈퇴)는 hard-delete.
+     * - 살아있는 동료가 있고 탈퇴 회원이 리더면 리더십을 이양한다.
+     *
+     * @return 탈퇴 회원이 살아남은 그룹 빙고에 여전히 참여자로 남아있으면 true(= tombstone 필요).
+     */
+    fun cleanUpBoardsOf(memberId: Long): Boolean {
+        return bingoBoardQueryRepository.findAllOf(memberId)
+            .map { cleanUpBoard(it, memberId) }
+            .any { it }
+    }
+
+    private fun cleanUpBoard(board: BingoBoard, memberId: Long): Boolean {
+        val livingOtherIds = livingOtherMemberIds(board, memberId)
+        if (livingOtherIds.isEmpty()) {
+            deleteBoard(board.id)
+            return false
+        }
+        if (board.isLeader(memberId)) {
+            bingoBoardCommandRepository.changeLeader(board.id, livingOtherIds.min())
+        }
+        return true
+    }
+
+    private fun livingOtherMemberIds(board: BingoBoard, memberId: Long): List<Long> {
+        val otherActiveIds = board.otherActiveMemberIdsOf(memberId)
+        return memberQueryRepository.findAllActive(otherActiveIds).map { it.id }
+    }
+
+    private fun deleteBoard(bingoBoardId: Long) {
+        notificationRepository.deleteAllByBingoBoardId(bingoBoardId)
+        bingoBoardCommandRepository.hardDelete(bingoBoardId)
+    }
+}

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/domain/WithdrawalGracePeriod.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/domain/WithdrawalGracePeriod.kt
@@ -1,0 +1,16 @@
+package com.beside.groubing.domain.withdrawal.domain
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class WithdrawalGracePeriod(
+    @Value("\${withdrawal.grace-days:365}") private val days: Long
+) {
+    init {
+        require(days > 0) { "탈퇴 유예기간은 1일 이상이어야 합니다. days: $days" }
+    }
+
+    fun calculateExpirationThreshold(now: LocalDateTime): LocalDateTime = now.minusDays(days)
+}

--- a/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/domain/WithdrawalGracePeriod.kt
+++ b/domain/gb-domain-core/src/main/kotlin/com/beside/groubing/domain/withdrawal/domain/WithdrawalGracePeriod.kt
@@ -1,16 +1,9 @@
 package com.beside.groubing.domain.withdrawal.domain
 
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
-@Component
-class WithdrawalGracePeriod(
-    @Value("\${withdrawal.grace-days:365}") private val days: Long
-) {
-    init {
-        require(days > 0) { "탈퇴 유예기간은 1일 이상이어야 합니다. days: $days" }
-    }
+object WithdrawalGracePeriod {
+    const val GRACE_DAYS = 365L
 
-    fun calculateExpirationThreshold(now: LocalDateTime): LocalDateTime = now.minusDays(days)
+    fun calculateExpirationThreshold(now: LocalDateTime): LocalDateTime = now.minusDays(GRACE_DAYS)
 }

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoMembersTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/bingo/domain/BingoMembersTest.kt
@@ -94,6 +94,35 @@ class BingoMembersTest : BehaviorSpec({
         }
     }
 
+    Given("electNextLeader") {
+        When("살아있는 멤버 중에서 다음 리더를 선출하면") {
+            val members = membersOf(participants = listOf(7L, 3L))
+
+            Then("가장 작은 memberId 를 반환한다.") {
+                members.electNextLeader(listOf(7L, 3L)) shouldBe 3L
+            }
+        }
+
+        When("빙고 내 비활성 멤버는 후보에서 제외하면") {
+            val members = membersOf(participants = listOf(3L, 7L))
+            members.inactivateOf(3L, bingoBoardId)
+
+            Then("활성 멤버 중 가장 작은 memberId 를 반환한다.") {
+                members.electNextLeader(listOf(3L, 7L)) shouldBe 7L
+            }
+        }
+
+        When("후보 중 빙고에 속한 살아있는 멤버가 없으면") {
+            val members = membersOf(participants = listOf(3L))
+
+            Then("BingoIllegalStateException 이 발생한다.") {
+                shouldThrow<BingoIllegalStateException> {
+                    members.electNextLeader(listOf(999L))
+                }.message shouldBe "리더를 이양할 살아있는 멤버가 없습니다."
+            }
+        }
+    }
+
     Given("addNewMembers") {
         When("새 회원들을 추가하면") {
             val members = membersOf(participants = emptyList())

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupServiceTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupServiceTest.kt
@@ -11,23 +11,23 @@ import java.time.LocalDateTime
 
 class ExpiredMemberCleanupServiceTest : BehaviorSpec({
     val memberQueryRepository = mockk<MemberQueryRepository>()
-    val memberCleanupExecutor = mockk<MemberCleanupExecutor>()
-    val cleanupService = ExpiredMemberCleanupService(memberQueryRepository, memberCleanupExecutor, graceDays = 365)
+    val memberCleaner = mockk<MemberCleaner>()
+    val cleanupService = ExpiredMemberCleanupService(memberQueryRepository, memberCleaner, graceDays = 365)
 
     Given("만료 회원 3명 중 1명 정리가 실패할 때") {
         val now = LocalDateTime.of(2026, 1, 1, 0, 0)
         every { memberQueryRepository.findExpiredMemberIds(any()) } returns listOf(1L, 2L, 3L)
-        every { memberCleanupExecutor.cleanup(1L) } just Runs
-        every { memberCleanupExecutor.cleanup(2L) } throws RuntimeException("boom")
-        every { memberCleanupExecutor.cleanup(3L) } just Runs
+        every { memberCleaner.cleanup(1L) } just Runs
+        every { memberCleaner.cleanup(2L) } throws RuntimeException("boom")
+        every { memberCleaner.cleanup(3L) } just Runs
 
         When("cleanupExpired 를 호출하면") {
             cleanupService.cleanupExpired(now)
 
             Then("한 명의 실패가 격리되고 나머지 회원도 모두 정리가 시도된다") {
-                verify(exactly = 1) { memberCleanupExecutor.cleanup(1L) }
-                verify(exactly = 1) { memberCleanupExecutor.cleanup(2L) }
-                verify(exactly = 1) { memberCleanupExecutor.cleanup(3L) }
+                verify(exactly = 1) { memberCleaner.cleanup(1L) }
+                verify(exactly = 1) { memberCleaner.cleanup(2L) }
+                verify(exactly = 1) { memberCleaner.cleanup(3L) }
             }
         }
     }

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupServiceTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupServiceTest.kt
@@ -1,6 +1,7 @@
 package com.beside.groubing.domain.withdrawal.application
 
 import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
+import com.beside.groubing.domain.withdrawal.domain.WithdrawalGracePeriod
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.Runs
 import io.mockk.every
@@ -12,7 +13,7 @@ import java.time.LocalDateTime
 class ExpiredMemberCleanupServiceTest : BehaviorSpec({
     val memberQueryRepository = mockk<MemberQueryRepository>()
     val memberCleaner = mockk<MemberCleaner>()
-    val cleanupService = ExpiredMemberCleanupService(memberQueryRepository, memberCleaner, graceDays = 365)
+    val cleanupService = ExpiredMemberCleanupService(memberQueryRepository, memberCleaner, WithdrawalGracePeriod(days = 365))
 
     Given("만료 회원 3명 중 1명 정리가 실패할 때") {
         val now = LocalDateTime.of(2026, 1, 1, 0, 0)

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupServiceTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/ExpiredMemberCleanupServiceTest.kt
@@ -1,7 +1,6 @@
 package com.beside.groubing.domain.withdrawal.application
 
 import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
-import com.beside.groubing.domain.withdrawal.domain.WithdrawalGracePeriod
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.Runs
 import io.mockk.every
@@ -13,7 +12,7 @@ import java.time.LocalDateTime
 class ExpiredMemberCleanupServiceTest : BehaviorSpec({
     val memberQueryRepository = mockk<MemberQueryRepository>()
     val memberCleaner = mockk<MemberCleaner>()
-    val cleanupService = ExpiredMemberCleanupService(memberQueryRepository, memberCleaner, WithdrawalGracePeriod(days = 365))
+    val cleanupService = ExpiredMemberCleanupService(memberQueryRepository, memberCleaner)
 
     Given("만료 회원 3명 중 1명 정리가 실패할 때") {
         val now = LocalDateTime.of(2026, 1, 1, 0, 0)

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleanerTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleanerTest.kt
@@ -17,14 +17,14 @@ import io.mockk.unmockkObject
 import io.mockk.verify
 import io.mockk.verifyOrder
 
-class MemberCleanupExecutorTest : BehaviorSpec({
+class MemberCleanerTest : BehaviorSpec({
     val notificationRepository = mockk<NotificationRepository>(relaxed = true)
     val friendCommandRepository = mockk<FriendCommandRepository>(relaxed = true)
     val blockedMemberRepository = mockk<BlockedMemberRepository>(relaxed = true)
     val socialInfoRepository = mockk<SocialInfoRepository>(relaxed = true)
     val withdrawnMemberBingoCleaner = mockk<WithdrawnMemberBingoCleaner>()
     val memberCommandRepository = mockk<MemberCommandRepository>()
-    val executor = MemberCleanupExecutor(
+    val memberCleaner = MemberCleaner(
         notificationRepository,
         friendCommandRepository,
         blockedMemberRepository,
@@ -44,7 +44,7 @@ class MemberCleanupExecutorTest : BehaviorSpec({
         every { FileStorage.delete(previousProfile) } just Runs
 
         When("cleanup 을 호출하면") {
-            executor.cleanup(memberId)
+            memberCleaner.cleanup(memberId)
 
             Then("연관 데이터 삭제 → 빙고 정리 → tombstone → 프로필 물리파일 삭제 순으로 수행된다") {
                 verifyOrder {
@@ -67,7 +67,7 @@ class MemberCleanupExecutorTest : BehaviorSpec({
         every { memberCommandRepository.hardDelete(memberId) } returns null
 
         When("cleanup 을 호출하면") {
-            executor.cleanup(memberId)
+            memberCleaner.cleanup(memberId)
 
             Then("tombstone 대신 회원을 완전 삭제하고 프로필 물리파일 삭제는 호출되지 않는다") {
                 verify(exactly = 1) { memberCommandRepository.hardDelete(memberId) }
@@ -85,7 +85,7 @@ class MemberCleanupExecutorTest : BehaviorSpec({
         every { FileStorage.delete(previousProfile) } just Runs
 
         When("cleanup 을 호출하면") {
-            executor.cleanup(memberId)
+            memberCleaner.cleanup(memberId)
 
             Then("완전 삭제 후 이전 프로필 물리파일을 삭제한다") {
                 verify(exactly = 1) { memberCommandRepository.hardDelete(memberId) }

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleanupExecutorTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/MemberCleanupExecutorTest.kt
@@ -15,54 +15,81 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
+import io.mockk.verifyOrder
 
 class MemberCleanupExecutorTest : BehaviorSpec({
     val notificationRepository = mockk<NotificationRepository>(relaxed = true)
     val friendCommandRepository = mockk<FriendCommandRepository>(relaxed = true)
     val blockedMemberRepository = mockk<BlockedMemberRepository>(relaxed = true)
     val socialInfoRepository = mockk<SocialInfoRepository>(relaxed = true)
+    val withdrawnMemberBingoCleaner = mockk<WithdrawnMemberBingoCleaner>()
     val memberCommandRepository = mockk<MemberCommandRepository>()
     val executor = MemberCleanupExecutor(
         notificationRepository,
         friendCommandRepository,
         blockedMemberRepository,
         socialInfoRepository,
+        withdrawnMemberBingoCleaner,
         memberCommandRepository
     )
 
     beforeSpec { mockkObject(FileStorage.Companion) }
     afterSpec { unmockkObject(FileStorage.Companion) }
 
-    Given("프로필이 있는 만료 회원이 주어졌을 때") {
+    Given("그룹 빙고에 잔존하고 프로필이 있는 만료 회원이 주어졌을 때") {
         val memberId = 7L
         val previousProfile = mockk<FileInfo>()
+        every { withdrawnMemberBingoCleaner.cleanUpBoardsOf(memberId) } returns true
         every { memberCommandRepository.tombstone(memberId, any()) } returns previousProfile
         every { FileStorage.delete(previousProfile) } just Runs
 
         When("cleanup 을 호출하면") {
             executor.cleanup(memberId)
 
-            Then("연관 데이터 삭제 + tombstone + 프로필 물리파일 삭제가 수행된다") {
+            Then("연관 데이터 삭제 → 빙고 정리 → tombstone → 프로필 물리파일 삭제 순으로 수행된다") {
+                verifyOrder {
+                    socialInfoRepository.deleteAllByMemberId(memberId)
+                    withdrawnMemberBingoCleaner.cleanUpBoardsOf(memberId)
+                    memberCommandRepository.tombstone(memberId, any())
+                    FileStorage.delete(previousProfile)
+                }
                 verify(exactly = 1) { notificationRepository.deleteAllByMemberId(memberId) }
                 verify(exactly = 1) { friendCommandRepository.deleteAllOf(memberId) }
                 verify(exactly = 1) { blockedMemberRepository.deleteAllOf(memberId) }
-                verify(exactly = 1) { socialInfoRepository.deleteAllByMemberId(memberId) }
-                verify(exactly = 1) { memberCommandRepository.tombstone(memberId, any()) }
-                verify(exactly = 1) { FileStorage.delete(previousProfile) }
+                verify(exactly = 0) { memberCommandRepository.hardDelete(any()) }
             }
         }
     }
 
-    Given("프로필이 없는 만료 회원이 주어졌을 때") {
+    Given("그룹 빙고에 잔존하지 않는 만료 회원이 주어졌을 때") {
         val memberId = 8L
-        every { memberCommandRepository.tombstone(memberId, any()) } returns null
+        every { withdrawnMemberBingoCleaner.cleanUpBoardsOf(memberId) } returns false
+        every { memberCommandRepository.hardDelete(memberId) } returns null
 
         When("cleanup 을 호출하면") {
             executor.cleanup(memberId)
 
-            Then("물리파일 삭제는 호출되지 않는다") {
-                verify(exactly = 1) { memberCommandRepository.tombstone(memberId, any()) }
+            Then("tombstone 대신 회원을 완전 삭제하고 프로필 물리파일 삭제는 호출되지 않는다") {
+                verify(exactly = 1) { memberCommandRepository.hardDelete(memberId) }
+                verify(exactly = 0) { memberCommandRepository.tombstone(any(), any()) }
                 verify(exactly = 0) { FileStorage.delete(any()) }
+            }
+        }
+    }
+
+    Given("그룹 빙고에 잔존하지 않고 프로필이 있는 만료 회원이 주어졌을 때") {
+        val memberId = 9L
+        val previousProfile = mockk<FileInfo>()
+        every { withdrawnMemberBingoCleaner.cleanUpBoardsOf(memberId) } returns false
+        every { memberCommandRepository.hardDelete(memberId) } returns previousProfile
+        every { FileStorage.delete(previousProfile) } just Runs
+
+        When("cleanup 을 호출하면") {
+            executor.cleanup(memberId)
+
+            Then("완전 삭제 후 이전 프로필 물리파일을 삭제한다") {
+                verify(exactly = 1) { memberCommandRepository.hardDelete(memberId) }
+                verify(exactly = 1) { FileStorage.delete(previousProfile) }
             }
         }
     }

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/WithdrawnMemberBingoCleanerTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/WithdrawnMemberBingoCleanerTest.kt
@@ -32,7 +32,6 @@ class WithdrawnMemberBingoCleanerTest : BehaviorSpec({
 
     Given("탈퇴 회원이 단독 보드만 가질 때") {
         every { bingoBoardQueryRepository.findAllOf(withdrawnMemberId) } returns listOf(aEmptyBingo())
-        every { memberQueryRepository.findAllActive(emptyList()) } returns emptyList()
 
         When("보드를 정리하면") {
             val remainsInGroupBingo = cleaner.cleanUpBoardsOf(withdrawnMemberId)
@@ -97,7 +96,6 @@ class WithdrawnMemberBingoCleanerTest : BehaviorSpec({
     Given("탈퇴 회원이 단독 보드와 리더인 그룹 보드를 함께 가질 때") {
         every { bingoBoardQueryRepository.findAllOf(withdrawnMemberId) } returns
             listOf(aEmptyBingo(), aEnglishStudyBingoBoard())
-        every { memberQueryRepository.findAllActive(emptyList()) } returns emptyList()
         every { memberQueryRepository.findAllActive(listOf(2L, 3L, 7L)) } returns
             listOf(activeMember(3L), activeMember(7L))
 

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/WithdrawnMemberBingoCleanerTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/application/WithdrawnMemberBingoCleanerTest.kt
@@ -1,0 +1,114 @@
+package com.beside.groubing.domain.withdrawal.application
+
+import com.beside.groubing.aEmptyBingo
+import com.beside.groubing.aEnglishStudyBingoBoard
+import com.beside.groubing.domain.bingo.domain.port.BingoBoardCommandRepository
+import com.beside.groubing.domain.bingo.domain.port.BingoBoardQueryRepository
+import com.beside.groubing.domain.member.domain.Member
+import com.beside.groubing.domain.member.domain.port.MemberQueryRepository
+import com.beside.groubing.domain.notification.domain.port.NotificationRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class WithdrawnMemberBingoCleanerTest : BehaviorSpec({
+    val bingoBoardQueryRepository = mockk<BingoBoardQueryRepository>()
+    val bingoBoardCommandRepository = mockk<BingoBoardCommandRepository>(relaxed = true)
+    val notificationRepository = mockk<NotificationRepository>(relaxed = true)
+    val memberQueryRepository = mockk<MemberQueryRepository>()
+    val cleaner = WithdrawnMemberBingoCleaner(
+        bingoBoardQueryRepository,
+        bingoBoardCommandRepository,
+        notificationRepository,
+        memberQueryRepository
+    )
+
+    fun activeMember(memberId: Long): Member = mockk { every { id } returns memberId }
+
+    // aEmptyBingo: id=1L, 멤버는 리더(memberId=1) 단독 / aEnglishStudyBingoBoard: id=2L, 리더 1 + 참여자 2,3,7
+    val withdrawnMemberId = 1L
+
+    Given("탈퇴 회원이 단독 보드만 가질 때") {
+        every { bingoBoardQueryRepository.findAllOf(withdrawnMemberId) } returns listOf(aEmptyBingo())
+        every { memberQueryRepository.findAllActive(emptyList()) } returns emptyList()
+
+        When("보드를 정리하면") {
+            val remainsInGroupBingo = cleaner.cleanUpBoardsOf(withdrawnMemberId)
+
+            Then("보드와 보드 알림을 hard-delete 하고 그룹 잔존이 아니다") {
+                remainsInGroupBingo shouldBe false
+                verify(exactly = 1) { notificationRepository.deleteAllByBingoBoardId(1L) }
+                verify(exactly = 1) { bingoBoardCommandRepository.hardDelete(1L) }
+                verify(exactly = 0) { bingoBoardCommandRepository.changeLeader(any(), any()) }
+            }
+        }
+    }
+
+    Given("탈퇴 회원이 리더인 그룹 보드를 가질 때") {
+        every { bingoBoardQueryRepository.findAllOf(withdrawnMemberId) } returns listOf(aEnglishStudyBingoBoard())
+        every { memberQueryRepository.findAllActive(listOf(2L, 3L, 7L)) } returns
+            listOf(activeMember(3L), activeMember(7L))
+
+        When("보드를 정리하면") {
+            val remainsInGroupBingo = cleaner.cleanUpBoardsOf(withdrawnMemberId)
+
+            Then("살아있는 동료 중 최소 id 에게 리더를 이양하고 그룹에 잔존한다") {
+                remainsInGroupBingo shouldBe true
+                verify(exactly = 1) { bingoBoardCommandRepository.changeLeader(2L, 3L) }
+                verify(exactly = 0) { bingoBoardCommandRepository.hardDelete(any()) }
+            }
+        }
+    }
+
+    Given("탈퇴 회원이 리더가 아닌 그룹 보드를 가질 때") {
+        val participantId = 2L
+        every { bingoBoardQueryRepository.findAllOf(participantId) } returns listOf(aEnglishStudyBingoBoard())
+        every { memberQueryRepository.findAllActive(listOf(1L, 3L, 7L)) } returns
+            listOf(activeMember(1L), activeMember(3L), activeMember(7L))
+
+        When("보드를 정리하면") {
+            val remainsInGroupBingo = cleaner.cleanUpBoardsOf(participantId)
+
+            Then("리더 이양 없이 그룹에 잔존한다") {
+                remainsInGroupBingo shouldBe true
+                verify(exactly = 0) { bingoBoardCommandRepository.changeLeader(any(), any()) }
+                verify(exactly = 0) { bingoBoardCommandRepository.hardDelete(any()) }
+            }
+        }
+    }
+
+    Given("그룹 보드의 동료가 전원 탈퇴(활성 계정 없음)일 때") {
+        every { bingoBoardQueryRepository.findAllOf(withdrawnMemberId) } returns listOf(aEnglishStudyBingoBoard())
+        every { memberQueryRepository.findAllActive(listOf(2L, 3L, 7L)) } returns emptyList()
+
+        When("보드를 정리하면") {
+            val remainsInGroupBingo = cleaner.cleanUpBoardsOf(withdrawnMemberId)
+
+            Then("살아있는 사람이 없으므로 보드를 hard-delete 하고 그룹 잔존이 아니다") {
+                remainsInGroupBingo shouldBe false
+                verify(exactly = 1) { bingoBoardCommandRepository.hardDelete(2L) }
+                verify(exactly = 0) { bingoBoardCommandRepository.changeLeader(any(), any()) }
+            }
+        }
+    }
+
+    Given("탈퇴 회원이 단독 보드와 리더인 그룹 보드를 함께 가질 때") {
+        every { bingoBoardQueryRepository.findAllOf(withdrawnMemberId) } returns
+            listOf(aEmptyBingo(), aEnglishStudyBingoBoard())
+        every { memberQueryRepository.findAllActive(emptyList()) } returns emptyList()
+        every { memberQueryRepository.findAllActive(listOf(2L, 3L, 7L)) } returns
+            listOf(activeMember(3L), activeMember(7L))
+
+        When("보드를 정리하면") {
+            val remainsInGroupBingo = cleaner.cleanUpBoardsOf(withdrawnMemberId)
+
+            Then("단독 보드는 삭제하고 그룹 보드는 이양하며 그룹에 잔존한다") {
+                remainsInGroupBingo shouldBe true
+                verify(exactly = 1) { bingoBoardCommandRepository.hardDelete(1L) }
+                verify(exactly = 1) { bingoBoardCommandRepository.changeLeader(2L, 3L) }
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/domain/WithdrawalGracePeriodTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/domain/WithdrawalGracePeriodTest.kt
@@ -1,0 +1,31 @@
+package com.beside.groubing.domain.withdrawal.domain
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class WithdrawalGracePeriodTest : BehaviorSpec({
+
+    Given("유예기간 365일이 주어졌을 때") {
+        val gracePeriod = WithdrawalGracePeriod(days = 365)
+
+        When("만료 기준 시각을 계산하면") {
+            val now = LocalDateTime.of(2026, 1, 1, 0, 0)
+
+            Then("now 에서 유예기간을 뺀 시각을 반환한다.") {
+                gracePeriod.calculateExpirationThreshold(now) shouldBe LocalDateTime.of(2025, 1, 1, 0, 0)
+            }
+        }
+    }
+
+    Given("유예기간이 0일 이하일 때") {
+        When("생성하면") {
+            Then("IllegalArgumentException 이 발생한다.") {
+                shouldThrow<IllegalArgumentException> {
+                    WithdrawalGracePeriod(days = 0)
+                }.message shouldBe "탈퇴 유예기간은 1일 이상이어야 합니다. days: 0"
+            }
+        }
+    }
+})

--- a/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/domain/WithdrawalGracePeriodTest.kt
+++ b/domain/gb-domain-core/src/test/kotlin/com/beside/groubing/domain/withdrawal/domain/WithdrawalGracePeriodTest.kt
@@ -1,30 +1,17 @@
 package com.beside.groubing.domain.withdrawal.domain
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import java.time.LocalDateTime
 
 class WithdrawalGracePeriodTest : BehaviorSpec({
 
-    Given("유예기간 365일이 주어졌을 때") {
-        val gracePeriod = WithdrawalGracePeriod(days = 365)
-
+    Given("탈퇴 유예기간(365일) 규칙이 있을 때") {
         When("만료 기준 시각을 계산하면") {
             val now = LocalDateTime.of(2026, 1, 1, 0, 0)
 
             Then("now 에서 유예기간을 뺀 시각을 반환한다.") {
-                gracePeriod.calculateExpirationThreshold(now) shouldBe LocalDateTime.of(2025, 1, 1, 0, 0)
-            }
-        }
-    }
-
-    Given("유예기간이 0일 이하일 때") {
-        When("생성하면") {
-            Then("IllegalArgumentException 이 발생한다.") {
-                shouldThrow<IllegalArgumentException> {
-                    WithdrawalGracePeriod(days = 0)
-                }.message shouldBe "탈퇴 유예기간은 1일 이상이어야 합니다. days: 0"
+                WithdrawalGracePeriod.calculateExpirationThreshold(now) shouldBe LocalDateTime.of(2025, 1, 1, 0, 0)
             }
         }
     }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoBoardEntity.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoBoardEntity.kt
@@ -8,6 +8,7 @@ import com.beside.groubing.domain.bingo.domain.BingoItems
 import com.beside.groubing.domain.bingo.domain.BingoMember
 import com.beside.groubing.domain.bingo.domain.BingoMembers
 import com.beside.groubing.domain.bingo.domain.BingoPeriod
+import com.beside.groubing.domain.bingo.exception.BingoInputException
 import com.beside.groubing.global.domain.jpa.BaseAggregateRoot
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
@@ -107,6 +108,13 @@ class BingoBoardEntity(
         bingoItems.forEach { item ->
             item.completeMembers.filter { it.memberId == memberId }.forEach { it.deactivate() }
         }
+    }
+
+    fun changeLeader(newLeaderId: Long) {
+        val newLeader = bingoMembers.find { it.memberId == newLeaderId }
+            ?: throw BingoInputException("이양 대상 멤버가 빙고에 없습니다. bingoBoardId: $id, memberId: $newLeaderId")
+        bingoMembers.filter { it.bingoMemberType.isLeader() }.forEach { it.demoteToParticipant() }
+        newLeader.promoteToLeader()
     }
 
     fun applyChanges(domain: BingoBoard) {

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoMemberEntity.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/entity/BingoMemberEntity.kt
@@ -17,8 +17,7 @@ import jakarta.persistence.Table
 class BingoMemberEntity(
     val memberId: Long,
 
-    @Enumerated(EnumType.STRING)
-    val bingoMemberType: BingoMemberType,
+    bingoMemberType: BingoMemberType,
 
     active: Boolean = true
 ) : BaseEntity() {
@@ -27,11 +26,23 @@ class BingoMemberEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L
 
+    @Enumerated(EnumType.STRING)
+    var bingoMemberType: BingoMemberType = bingoMemberType
+        private set
+
     var active: Boolean = active
         private set
 
     fun deactivate() {
         this.active = false
+    }
+
+    fun promoteToLeader() {
+        this.bingoMemberType = BingoMemberType.LEADER
+    }
+
+    fun demoteToParticipant() {
+        this.bingoMemberType = BingoMemberType.PARTICIPANT
     }
 
     fun applyChanges(domain: BingoMember) {

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapter.kt
@@ -62,6 +62,14 @@ class BingoBoardRepositoryAdapter(
         findActiveEntityById(bingoBoardId).deactivateMember(memberId)
     }
 
+    override fun changeLeader(bingoBoardId: Long, newLeaderId: Long) {
+        findActiveEntityById(bingoBoardId).changeLeader(newLeaderId)
+    }
+
+    override fun hardDelete(bingoBoardId: Long) {
+        bingoBoardJpaRepository.deleteById(bingoBoardId)
+    }
+
     override fun findOne(id: Long): BingoBoard = findActiveEntityById(id).toDomain()
 
     override fun findAllOf(memberId: Long): List<BingoBoard> =

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapter.kt
@@ -42,6 +42,13 @@ class MemberRepositoryAdapter(
         return previousProfile
     }
 
+    override fun hardDelete(memberId: Long): FileInfo? {
+        val entity = findEntityById(memberId)
+        val previousProfile = entity.profile?.toDomain()
+        memberJpaRepository.delete(entity)
+        return previousProfile
+    }
+
     override fun editProfileOrNull(memberId: Long, newProfile: FileInfo): FileInfo? {
         val entity = findActiveEntityById(memberId)
         val previous = entity.profile?.toDomain()

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/notification/repository/NotificationJpaRepository.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/notification/repository/NotificationJpaRepository.kt
@@ -13,4 +13,6 @@ interface NotificationJpaRepository : JpaRepository<NotificationEntity, Long> {
     ): Page<NotificationEntity>
 
     fun deleteByMemberId(memberId: Long)
+
+    fun deleteByBingoBoardId(bingoBoardId: Long)
 }

--- a/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/notification/repository/NotificationRepositoryAdapter.kt
+++ b/infrastructure/storage/gb-db-core/src/main/kotlin/com/beside/groubing/domain/notification/repository/NotificationRepositoryAdapter.kt
@@ -21,6 +21,10 @@ class NotificationRepositoryAdapter(
         notificationJpaRepository.deleteByMemberId(memberId)
     }
 
+    override fun deleteAllByBingoBoardId(bingoBoardId: Long) {
+        notificationJpaRepository.deleteByBingoBoardId(bingoBoardId)
+    }
+
     override fun findRecentOf(bingoBoardIds: List<Long>, myMemberId: Long): List<NotificationItem> {
         return notificationFindDao.findNotifications(bingoBoardIds, myMemberId)
             .map {

--- a/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapterTest.kt
+++ b/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/bingo/repository/BingoBoardRepositoryAdapterTest.kt
@@ -141,6 +141,51 @@ class BingoBoardRepositoryAdapterTest(
         }
     }
 
+    describe("changeLeader") {
+        context("리더를 다른 멤버에게 이양하면") {
+            it("기존 리더는 PARTICIPANT 로, 신규 리더는 LEADER 로 바뀌고 나머지 멤버는 그대로 유지된다") {
+                val saved = bingoBoardJpaRepository.save(BingoBoardEntity.from(aEnglishStudyBingoBoard()))
+                val savedId = saved.id
+                val originalMemberCount = saved.bingoMembers.size
+
+                bingoBoardRepositoryAdapter.changeLeader(savedId, 2L)
+                testEntityManager.flush()
+                testEntityManager.clear()
+
+                val reloaded = bingoBoardJpaRepository.findById(savedId).orElseThrow()
+                reloaded.bingoMembers.first { it.memberId == 1L }.bingoMemberType shouldBe BingoMemberType.PARTICIPANT
+                reloaded.bingoMembers.first { it.memberId == 2L }.bingoMemberType shouldBe BingoMemberType.LEADER
+                reloaded.bingoMembers.filter { it.memberId !in setOf(1L, 2L) }.forEach {
+                    it.bingoMemberType shouldBe BingoMemberType.PARTICIPANT
+                }
+                reloaded.bingoMembers.size shouldBe originalMemberCount
+            }
+        }
+    }
+
+    describe("hardDelete") {
+        context("보드를 완전 삭제하면") {
+            it("보드와 멤버/아이템/완료기록이 모두 함께 삭제된다") {
+                val board = aEnglishStudyBingoBoard()
+                board.completeBingoItem(bingoItemId = 1L, memberId = 2L)
+                val saved = bingoBoardJpaRepository.save(BingoBoardEntity.from(board))
+                val savedId = saved.id
+                testEntityManager.flush()
+
+                bingoBoardRepositoryAdapter.hardDelete(savedId)
+                testEntityManager.flush()
+                testEntityManager.clear()
+
+                fun countOf(entity: String) =
+                    testEntityManager.entityManager.createQuery("select count(e) from $entity e").singleResult as Long
+                bingoBoardJpaRepository.findById(savedId).isPresent shouldBe false
+                countOf("BingoMemberEntity") shouldBe 0L
+                countOf("BingoItemEntity") shouldBe 0L
+                countOf("BingoCompleteMemberEntity") shouldBe 0L
+            }
+        }
+    }
+
     describe("updateMemo") {
         context("리더가 메모를 변경하면") {
             it("메모만 갱신되고 멤버/아이템은 그대로 유지된다") {

--- a/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapterTest.kt
+++ b/infrastructure/storage/gb-db-core/src/test/kotlin/com/beside/groubing/domain/member/repository/MemberRepositoryAdapterTest.kt
@@ -98,6 +98,15 @@ class MemberRepositoryAdapterTest(
         entity.cleanedAt shouldNotBe null
     }
 
+    test("hardDelete 하면 회원 row 가 완전히 삭제되고 이전 프로필이 반환된다") {
+        val saved = memberRepositoryAdapter.save(newMember(loginId = "hd", nickname = "hdNick"))
+
+        val previousProfile = memberRepositoryAdapter.hardDelete(saved.id)
+
+        memberJpaRepository.findById(saved.id).isPresent shouldBe false
+        previousProfile shouldBe null
+    }
+
     test("findExpiredMemberIds 는 기준 이전 탈퇴 + 미정리(cleanedAt null) 회원만 반환한다") {
         val expired = memberRepositoryAdapter.save(newMember(loginId = "exp", nickname = "expNick"))
         val recent = memberRepositoryAdapter.save(newMember(loginId = "rec", nickname = "recNick"))


### PR DESCRIPTION
## 개요
회원 탈퇴 정책 **Phase 3b**. 1년 경과 탈퇴 회원 정리 잡(3a)에 **빙고 보드 정리 + 리더 이양 + 조건부 회원 완전삭제**를 얹는다.

3a는 회원을 무조건 tombstone 했지만, Phase 2 그룹 빙고 익명표시(B 변형)는 Member row를 읽어 익명화하므로 **그룹 빙고 참여자를 완전삭제하면 표시가 깨진다**. 따라서 그룹 빙고 잔존 여부로 분기한다.

## 처리 로직 (`MemberCleanupExecutor.cleanup`, 회원별 @Transactional)
연관 데이터 삭제(notification/friend/blocked/social) → **빙고 정리** → 회원 제거(조건부) → 이전 프로필 물리파일 삭제.

### 빙고 정리 (`WithdrawnMemberBingoCleaner`, 신규)
회원이 속한 활성 보드별로:
- **살아있는 동료(빙고 active + 계정 active) 없음** → 보드 + 보드 알림 `hard-delete` (단독 보드 / 동료 전원 탈퇴)
- **살아있는 동료 있음 + 회원이 리더** → 최소 memberId 동료에게 **리더 이양**
- **살아있는 동료 있음 + 비리더** → 그대로 유지(잔존)

→ 살아남은 그룹 보드에 회원이 남으면 `true`(tombstone 필요) 반환.

### 회원 제거 (조건부)
- 그룹 빙고 **잔존** → `tombstone` (Phase 2 익명표시 '탈퇴한 회원' 보존)
- 그룹 빙고 **미참여** → `hardDelete` (row 완전 삭제, FileInfo? 캐스케이드)

## 신규 surface (기존 `deactivateBingoMember` 타깃 op 패턴)
- `BingoBoardCommandRepository.changeLeader(bingoBoardId, newLeaderId)` / `hardDelete(bingoBoardId)`
- `MemberCommandRepository.hardDelete(memberId): FileInfo?`
- `NotificationRepository.deleteAllByBingoBoardId(bingoBoardId)`
- 엔티티: `BingoMemberEntity` 타입 가변화 + `promoteToLeader`/`demoteToParticipant`, `BingoBoardEntity.changeLeader`

## 설계 노트
- **회원별 트랜잭션 격리**: `@Transactional`은 3a대로 per-member `MemberCleanupExecutor`에 유지 — 한 명 실패가 전체 정리를 막지 않음(`ExpiredMemberCleanupService`가 runCatching 으로 격리).
- **리더 이양 대상**: 빙고 active 동료 중 **계정 살아있는(미탈퇴)** 멤버만(`findAllActive`) → 결정적으로 최소 memberId. 동료 전원 탈퇴면 살릴 사람이 없으므로 보드 삭제.
- **보드 cascade**: `BingoBoardEntity`의 members/items/completeMembers가 cascade ALL + orphanRemoval이라 `deleteById`로 함께 삭제.

## 테스트
- 단위: `WithdrawnMemberBingoCleanerTest`(단독/리더그룹/비리더그룹/동료전원탈퇴/혼합 5케이스), `MemberCleanupExecutorTest`(잔존→tombstone / 미참여→hardDelete / 순서·프로필 삭제)
- persistence: `BingoBoardRepositoryAdapterTest`(리더 이양 영속화, 보드+자식 cascade 삭제), `MemberRepositoryAdapterTest`(회원 row 완전삭제)
- 회귀: `./gradlew build` 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)